### PR TITLE
Strip biosdevname and net.ifnames flags for Debian 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) t
 ## Unreleased
 
 ### Added
- - workflow mode to allow users to execute workflows 
+- Strip biosdevname and net.ifname GRUB flags for Debian 10
+- workflow mode to allow users to execute workflows

--- a/grub/debian_10-c1.large.arm-grub.template
+++ b/grub/debian_10-c1.large.arm-grub.template
@@ -91,7 +91,7 @@ menuentry 'Debian' --class debian --class gnu-linux --class gnu --class os --unr
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 biosdevname=0 net.ifnames=1 crashkernel=auto LANG=en_US.UTF-8
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8
 		initrd /boot/initrd
 }
 

--- a/grub/debian_10-c1.large.arm-grub.template.default
+++ b/grub/debian_10-c1.large.arm-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 biosdevname=0 net.ifnames=1 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8'
 GRUB_SERIAL_COMMAND='serial'

--- a/grub/debian_10-c1.small.x86-grub.template
+++ b/grub/debian_10-c1.small.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-c1.small.x86-grub.template.default
+++ b/grub/debian_10-c1.small.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-c1.xlarge.x86-grub.template
+++ b/grub/debian_10-c1.xlarge.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=igb
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-c1.xlarge.x86-grub.template.default
+++ b/grub/debian_10-c1.xlarge.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=igb'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-c2.large.anbox-grub.template
+++ b/grub/debian_10-c2.large.anbox-grub.template
@@ -91,7 +91,7 @@ menuentry 'Debian' --class debian --class gnu-linux --class gnu --class os --unr
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 biosdevname=0 net.ifnames=1 crashkernel=auto LANG=en_US.UTF-8
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8
 		initrd /boot/initrd
 }
 

--- a/grub/debian_10-c2.large.anbox-grub.template.default
+++ b/grub/debian_10-c2.large.anbox-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 biosdevname=0 net.ifnames=1 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8'
 GRUB_SERIAL_COMMAND='serial'

--- a/grub/debian_10-c2.large.arm-grub.template
+++ b/grub/debian_10-c2.large.arm-grub.template
@@ -91,7 +91,7 @@ menuentry 'Debian' --class debian --class gnu-linux --class gnu --class os --unr
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 biosdevname=0 net.ifnames=1 crashkernel=auto LANG=en_US.UTF-8
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8
 		initrd /boot/initrd
 }
 

--- a/grub/debian_10-c2.large.arm-grub.template.default
+++ b/grub/debian_10-c2.large.arm-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 biosdevname=0 net.ifnames=1 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8'
 GRUB_SERIAL_COMMAND='serial'

--- a/grub/debian_10-c2.medium.x86-grub.template
+++ b/grub/debian_10-c2.medium.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-c2.medium.x86-grub.template.default
+++ b/grub/debian_10-c2.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-c2.small.x86-grub.template
+++ b/grub/debian_10-c2.small.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-c2.small.x86-grub.template.default
+++ b/grub/debian_10-c2.small.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-c3.medium.x86-grub.template
+++ b/grub/debian_10-c3.medium.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-c3.medium.x86-grub.template.default
+++ b/grub/debian_10-c3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-c3.small.x86-grub.template
+++ b/grub/debian_10-c3.small.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-c3.small.x86-grub.template.default
+++ b/grub/debian_10-c3.small.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-cpe1.c1.r720xd-grub.template
+++ b/grub/debian_10-cpe1.c1.r720xd-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-cpe1.c1.r720xd-grub.template.default
+++ b/grub/debian_10-cpe1.c1.r720xd-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-g2.large.x86-grub.template
+++ b/grub/debian_10-g2.large.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-g2.large.x86-grub.template.default
+++ b/grub/debian_10-g2.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-m1.xlarge.x86-grub.template
+++ b/grub/debian_10-m1.xlarge.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-m1.xlarge.x86-grub.template.default
+++ b/grub/debian_10-m1.xlarge.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-m2.xlarge.x86-grub.template
+++ b/grub/debian_10-m2.xlarge.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=igb
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-m2.xlarge.x86-grub.template.default
+++ b/grub/debian_10-m2.xlarge.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=igb'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-m3.large.x86-grub.template
+++ b/grub/debian_10-m3.large.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-m3.large.x86-grub.template.default
+++ b/grub/debian_10-m3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-n2.xlarge.google-grub.template
+++ b/grub/debian_10-n2.xlarge.google-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-n2.xlarge.google-grub.template.default
+++ b/grub/debian_10-n2.xlarge.google-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-n2.xlarge.x86-grub.template
+++ b/grub/debian_10-n2.xlarge.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=igb
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-n2.xlarge.x86-grub.template.default
+++ b/grub/debian_10-n2.xlarge.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=igb'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-s1.large.x86-grub.template
+++ b/grub/debian_10-s1.large.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=ixgbe $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-s1.large.x86-grub.template.default
+++ b/grub/debian_10-s1.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=ixgbe'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-s2.large.x86-grub.template
+++ b/grub/debian_10-s2.large.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=ixgbe $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-s2.large.x86-grub.template.default
+++ b/grub/debian_10-s2.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 modprobe.blacklist=ixgbe'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-s3.xlarge.x86-grub.template
+++ b/grub/debian_10-s3.xlarge.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-s3.xlarge.x86-grub.template.default
+++ b/grub/debian_10-s3.xlarge.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-t1.small.x86-grub.template
+++ b/grub/debian_10-t1.small.x86-grub.template
@@ -43,7 +43,7 @@ menuentry 'Debian' --class debian --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -60,6 +60,6 @@ menuentry 'Debian - single user mode' --class debian --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-t1.small.x86-grub.template.default
+++ b/grub/debian_10-t1.small.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-t3.small.x86-grub.template
+++ b/grub/debian_10-t3.small.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-t3.small.x86-grub.template.default
+++ b/grub/debian_10-t3.small.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-t3.xsmall.x86-grub.template
+++ b/grub/debian_10-t3.xsmall.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-t3.xsmall.x86-grub.template.default
+++ b/grub/debian_10-t3.xsmall.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-x1.small.x86-grub.template
+++ b/grub/debian_10-x1.small.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-x1.small.x86-grub.template.default
+++ b/grub/debian_10-x1.small.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-x2.graphcore.x86-grub.template
+++ b/grub/debian_10-x2.graphcore.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-x2.graphcore.x86-grub.template.default
+++ b/grub/debian_10-x2.graphcore.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-x2.xlarge.x86-grub.template
+++ b/grub/debian_10-x2.xlarge.x86-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-x2.xlarge.x86-grub.template.default
+++ b/grub/debian_10-x2.xlarge.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'


### PR DESCRIPTION
- [x] Changelog updated
