### PR TITLE
Remove c3.medium from kexec bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) t
 ## Unreleased
 
 ### Added
+- Remove c3.medium from kexec bypass
 - Strip biosdevname and net.ifname GRUB flags for Debian 10
 - workflow mode to allow users to execute workflows

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -540,8 +540,6 @@ elif [[ ${OS} =~ ubuntu_16_04 && ${class} == t3.small.x86 ]]; then
 	echo -en '#!/bin/sh\nreboot\n' >/statedir/cleanup.sh
 elif [[ ${class} == c2.medium.x86 ]]; then
 	echo -en '#!/bin/sh\nreboot\n' >/statedir/cleanup.sh
-elif [[ ${class} == c3.medium.x86 ]]; then
-	echo -en '#!/bin/sh\nreboot\n' >/statedir/cleanup.sh
 fi
 
 chmod +x /statedir/cleanup.sh


### PR DESCRIPTION
We opted for BIOS over UEFI for this plan, so we can kexec in now

- [x] Changelog updated
