### PR TITLE
fixes jq syntax on alpine 3.11

### DIFF
--- a/installer/osie-installer.sh
+++ b/installer/osie-installer.sh
@@ -95,7 +95,7 @@ if [ "$slug" = 'custom_ipxe' ]; then
 	mv "$metadata.tmp" "$metadata"
 fi
 
-jq -S '. + {"password_hash":"'"$pwhash"'", "state": (.state?//"'"$state"'")}' <"$metadata" >"$metadata.tmp"
+jq -S '. + {"password_hash":"'"$pwhash"'", "state": (.state? // "'"$state"'")}' <"$metadata" >"$metadata.tmp"
 mv "$metadata.tmp" "$metadata"
 echo "tweaked metadata:"
 jq -S . "$metadata"


### PR DESCRIPTION
- resolves issue #13.
- jq syntax is valid for Alpine 3.7 and Alpine 3.11