### PR TITLE
Remove Supermicro Gen3 UEFI workarounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) t
 ## Unreleased
 
 ### Added
+- Remove Supermicro UEFI workarounds
 - Add Ubuntu 20.04 repos
 - Enable kexec bypass for centos 8 on t1.small.x86
 - Add Ubuntu 20.04 GRUB templates

--- a/docker/scripts/grub-installer.sh
+++ b/docker/scripts/grub-installer.sh
@@ -153,8 +153,3 @@ for disk in $bootdevs; do
 		install_grub_osie
 	fi
 done
-
-# Workaround for Supermicro UEFI shell issue (ENG-4045)
-if [[ $plan == "c3.small.x86" ]] || [[ $plan == "s3.xlarge.x86" ]]; then
-	$uefi && echo "exit" >"$target/boot/efi/startup.nsh"
-fi


### PR DESCRIPTION
We're not using UEFI for these instance types anymore so we don't need 
this code

- [x] Changelog updated
