### PR TITLE
installer/workflow-helper-rc: add command_background=true

### DIFF
--- a/installer/workflow-helper-rc
+++ b/installer/workflow-helper-rc
@@ -2,3 +2,5 @@
 
 name="Packet Workflow"
 command="/sbin/workflow-helper"
+command_background=true
+pidfile=/run/workflow-helper.pid


### PR DESCRIPTION
This commit adds command_background=true option to workflow-helper
openrc file, so it will run in the background instead of blocking
execution process.

This will unblock spawning the TTY process, which might be helpful while
debugging, as currently the workflow-helper script may run infinitely,
which causes TTY to never spawn.

Closes #22

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

- [ ] Changelog updated
