### PR TITLE
installer/workflow-helper.sh: don't use -i in docker run

### DIFF
--- a/installer/workflow-helper.sh
+++ b/installer/workflow-helper.sh
@@ -57,7 +57,7 @@ done
 # stop mdev from messing with us once and for all
 rm -f /sbin/mdev
 
-docker run -dit --net host \
+docker run -dt --net host \
 	"$docker_registry/fluent-bit:1.3" \
 	/fluent-bit/bin/fluent-bit -i forward -o "es://$elastic_search_url/worker/worker"
 
@@ -66,7 +66,7 @@ sleep 3
 
 mkdir /worker
 
-docker run --privileged -ti \
+docker run --privileged -t \
 	-e "container_uuid=$id" \
 	-e "WORKER_ID=$worker_id" \
 	-e "DOCKER_REGISTRY=$docker_registry" \


### PR DESCRIPTION
It seems running multiple containers with -i does not work when executed
from openrc service and causes 2nd container to fail to start.

It also doesn't make much sense to run with -i, as those are not really
an interactive sessions.

-t stays for both commands, if one wants to use 'docker attach' for some
reason.

Closes #21

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

- [ ] Changelog updated
