### PR TITLE
Bypass kexec for c3.medium and Ubuntu 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) t
 ## Unreleased
 
 ### Added
+- Bypass kexec for c3.medium and Ubuntu 16
 - Remove Supermicro UEFI workarounds
 - Add Ubuntu 20.04 repos
 - Enable kexec bypass for centos 8 on t1.small.x86

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -539,6 +539,7 @@ echo -e "${BYELLOW}Install time: $((etimer - stimer))${NC}"
 case ${OS}:${class} in
 centos_8:t1.small.x86) reboot=true ;;
 ubuntu_18_04:t1.small.x86) reboot=true ;;
+ubuntu_16_04:c3.medium.x86) reboot=true ;;
 ubuntu_16_04:t3.small.x86) reboot=true ;;
 *:c2.medium.x86) reboot=true ;;
 esac


### PR DESCRIPTION
These installs hang at the kexec step, lets not use that method here and 
suffer the delayed provisioning time instead.

- [x] Changelog updated
