### PR TITLE
Use OS name without tags when bypassing kexec

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -536,7 +536,7 @@ etimer=$(date +%s)
 echo -e "${BYELLOW}Install time: $((etimer - stimer))${NC}"
 
 # Bypass kexec for certain OS plan combos
-case ${OS}:${class} in
+case ${os}:${class} in
 centos_8:t1.small.x86) reboot=true ;;
 ubuntu_18_04:t1.small.x86) reboot=true ;;
 ubuntu_20_04:t1.small.x86) reboot=true ;;


### PR DESCRIPTION
Previously when using $OS, we were also getting the git sha information
(e.g, ubuntu_18_04:496672e4078006e92bdd70ca2c3cfcee6e060fdc), which
broke the logic of the case statement. $os, on the other hand, should
give us what was originally intended.

- [ ] Changelog updated
