### PR TITLE
Read eclypsium token from kernel cmdline | ENG-5336

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -207,19 +207,15 @@ baremetal_2a2 | baremetal_2a4 | baremetal_2a5 | baremetal_hua)
 esac
 
 # Run eclypsium
-if [[ $arch == x86_64 ]]; then
-	case "$facility" in
-	ssg-* | att-*)
-		echo "skipping eclypsium in unsupported facility"
-		;;
-	*)
+if [[ -n "${ECLYPSIUM_TOKEN:-}" ]]; then
+	if [[ $arch == x86_64 ]]; then
 		case "$class" in
 		disabled.plan.here)
 			echo "skipping eclypsium on unsuppported plan"
 			;;
 		*)
 			https_proxy="http://eclypsium-proxy-${facility}.packet.net:8888/" /usr/bin/EclypsiumApp \
-				-s1 prod-0918.eclypsium.net placeholder \
+				-s1 prod-0918.eclypsium.net "${ECLYPSIUM_TOKEN}" \
 				-disable-progress-bar \
 				-medium \
 				-log stderr \
@@ -227,8 +223,7 @@ if [[ $arch == x86_64 ]]; then
 				-custom-id "${id}" || echo 'EclypsiumApp Failed!'
 			;;
 		esac
-		;;
-	esac
+	fi
 fi
 
 phone_home "${tinkerbell}" '{"type":"deprovisioning.306.02","body":"Deprovision finished, rebooting server","private":true}'

--- a/installer/osie-installer.sh
+++ b/installer/osie-installer.sh
@@ -63,6 +63,7 @@ arch=$(uname -m)
 packet_base_url=$(sed -nr 's|.*\bpacket_base_url=(\S+).*|\1|p' /proc/cmdline)
 pwhash=$(sed -nr 's|.*\bpwhash=(\S+).*|\1|p' /proc/cmdline)
 kslug=$(sed -nr 's|.*\bslug=(\S+).*|\1|p' /proc/cmdline)
+eclypsium_token=$(sed -nr 's|.*\beclypsium_token=(\S+).*|\1|p' /proc/cmdline)
 
 case $kslug in
 *deprovision*) state=deprovision ;;
@@ -173,6 +174,7 @@ docker run --privileged -ti \
 	-h "${hardware_id}" \
 	-e "container_uuid=$id" \
 	-e "RLOGHOST=$tinkerbell" \
+	-e "ECLYPSIUM_TOKEN=${eclypsium_token:-}" \
 	-v /dev:/dev \
 	-v /dev/console:/dev/console \
 	-v /lib/firmware:/lib/firmware:ro \


### PR DESCRIPTION
    Provide an eclypsium scanning token during runtime to avoid having to hard code
    it into osie.

    * Parse eclypsium_token= from /proc/cmdline
    * Pass eclypsium_token to osie 'mode' script as env ECLYPSIUM_TOKEN
    * Utilize passed token in EclypsiumApp scanner invocation