### PR TITLE
Pull in updated packet-networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) t
 ## Unreleased
 
 ### Added
+- Update packet-networking submodule (for some retry logic)
 - Add Ubuntu 20.10 GRUB templates
 - Add missing x.small GRUB templates
 - Bypass kexec for t1.small and Ubuntu 20


### PR DESCRIPTION
This newer version of packet-networking includes some retry logic that 
we were missing and some Ubuntu 20.10 networking logic

- [x] Changelog updated
