### PR TITLE
Revert "Prefer our local github-mirror for packet-images repo access"

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -664,34 +664,6 @@ function ensure_reachable() {
 	echo -e "${YELLOW}###### OK${NC}"
 }
 
-# Check that our git-lfs mirror server is working
-function github_mirror_check() {
-	echo -e "${YELLOW}###### Checking the health of github-mirror.packet.net...${NC}"
-
-	# Clone the repo, and checkout an LFS branch.
-	local timeout=30 # seconds
-	local lfs_testing_uri="https://github-mirror.packet.net/packethost/lfs-testing.git"
-	local lfs_testing_branch="remotes/origin/images-tiny"
-	if ! timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then
-		echo -e "${YELLOW}###### Timeout when cloning the lfs-testing repo${NC}"
-		return 1
-	fi
-	cd lfs-testing
-	if ! timeout --preserve-status $timeout git checkout -q $lfs_testing_branch; then
-		cd .. && rm -rf lfs-testing
-		echo -e "${YELLOW}###### Timeout when checking out git-lfs data from lfs-testing${NC}"
-		return 1
-	fi
-	checksum=$(sha256sum tiny/tiny.img | awk '{ print $1 }')
-	cd .. && rm -rf lfs-testing
-
-	local valid_checksum="7b331c02e313c7599d5a90212e17e6d3cb729bd2e1c9b873c302a63c95a2f9bf"
-	if [[ "$checksum" != "$valid_checksum" ]]; then
-		echo -e "${YELLOW}###### Test git-lfs checkout from github-mirror had a bad checksum${NC}"
-		return 1
-	fi
-}
-
 # determine the default interface to use if ip=dhcp is set
 # uses "PACKET_BOOTDEV_MAC" kopt value if it exists
 # if none, will use the first "eth" interface that has a carrier link

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -130,18 +130,11 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 	mkdir $assetdir
 	echo -e "${GREEN}#### Fetching image (and more) via git ${NC}"
 
-	# config hosts entry so git-lfs assets from github and our github-mirror are
-	# pulled through our image cache
-	githost="github-mirror.packet.net"
-	if ! (ensure_reachable github-mirror.packet.net && github_mirror_check); then
-		echo -e "${YELLOW}###### github-mirror health check failed, falling back to using github.com${NC}"
-		githost="github.com"
-	fi
-	images_ip=$(getent hosts images.packet.net | awk '{print $1}')
+	# config hosts entry so git-lfs assets are pulled through our image cache
+	githost="images.packet.net"
+	images_ip=$(getent hosts $githost | awk '{print $1}')
 	cp -a /etc/hosts /etc/hosts.new
-	echo "$images_ip        github-cloud.s3.amazonaws.com" >>/etc/hosts.new
-	echo "$images_ip        $githost" >>/etc/hosts.new
-	cp -f /etc/hosts.new /etc/hosts
+	echo "$images_ip        github-cloud.s3.amazonaws.com" >>/etc/hosts.new && cp -f /etc/hosts.new /etc/hosts
 	echo -n "LFS pulls via github-cloud will now resolve to image cache:"
 	getent hosts github-cloud.s3.amazonaws.com | awk '{print $1}'
 


### PR DESCRIPTION
This reverts commit ae6ea020a52c2eb059b504f52e6e615ad3ed2f93.

I've been unable to get this fully deployed to our rancher sites, and in the meantime we have some other urgent work that's come in, so reverting this temporarily until the rancher deployment issues are fully understood.
