### PR TITLE
Add git-lfs debugging output during image checkouts

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -144,6 +144,8 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 		gitpath="packethost/packet-images.git"
 		gituri="https://${githost}/${gitpath}"
 
+		# Address intermittent LFS smudge failures by increasing maxretries
+		git config --global lfs.transfer.maxtretries 10
 		# TODO - figure how we can do SSL passthru for github-cloud to images cache
 		git config --global http.sslverify false
 	elif [[ $custom_image == true ]]; then
@@ -158,7 +160,8 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 	git -C $assetdir init
 	git -C $assetdir remote add origin "${gituri}"
 	git -C $assetdir fetch origin
-	git -C $assetdir checkout "${image_tag}"
+	echo -e "${GREEN}#### Checking out: ${image_tag}${NC}"
+	GIT_TRACE=1 git -C $assetdir checkout "${image_tag}"
 
 	OS=${OS%%:*}
 


### PR DESCRIPTION
- Show the sha/image tag being checked out
- Enable GIT_TRACE=1 during checkout to show verbose connection logging
- Set lfs.transfer.maxtretries to 10 to increase LFS retries

I've been getting LFS "smudge" failures pretty regularly at some sites (yyz1 and hkg1), and I'd like to deploy an osie with these changes on a temporary basis to see if it can fix these issues or help troubleshoot the root cause.
