### PR TITLE
Upgrade git to 2.27 for improved shallow clone support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -y && \
 COPY build-git-openssl.sh /tmp/osie/
 RUN apt-get update -y && \
     /tmp/osie/build-git-openssl.sh && \
-    dpkg --unpack /tmp/osie/git_*.deb /tmp/osie/git-core_*.deb /tmp/osie/git-man_*.deb && \
+    dpkg --unpack /tmp/osie/git_*.deb && \
     apt-get install -f -y --no-install-recommends && \
     apt-get -y autoremove && \
     apt-get -y clean && \

--- a/docker/build-git-openssl.sh
+++ b/docker/build-git-openssl.sh
@@ -4,7 +4,13 @@ set -euxo nounset
 
 d=$(mktemp -d)
 cd "$d"
+apt-get install -y software-properties-common
+# The version of git that comes with Xenial (2.7.4) doesn't support shallow
+# clones from our github-mirror server, so use the latest officially supported
+# Xenial release from the Ubuntu git maintainers PPA
+add-apt-repository -y ppa:git-core/ppa
 sed -i 's|^# deb-src|deb-src|' /etc/apt/sources.list
+sed -i 's|^# deb-src|deb-src|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-xenial.list
 apt-get update
 
 # this is to get mk-build-deps which creates a virtual package that deps on the
@@ -47,7 +53,7 @@ apt-get source git
 	dpkg-buildpackage -rfakeroot -b -j"$(nproc)"
 )
 mv ./*.deb /tmp/osie
-apt-get purge -y devscripts equivs libcurl4-openssl-dev
+apt-get purge -y devscripts equivs libcurl4-openssl-dev software-properties-common
 apt-get autoremove -y
 cd
 rm -rf "$d"


### PR DESCRIPTION
The version of git that comes with Xenial (2.7.4) doesn't support
shallow clones from our github-mirror server, so use the latest
officially supported Xenial release from the Ubuntu git maintainers PPA.