### PR TITLE
Always fetch metadata from using https

### DIFF
--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -348,7 +348,7 @@ do_test() {
 	# 1. do not verify https cert for metadata.packet.net since we dont want to add real cert here
 	# 2. poweroff instead of reboot after install
 	sed -i \
-		-e '/^ensure_time$/ s|^|curl http://metadata.packet.net/bundle.pem >/tmp/caddy-cert.pem\n|' \
+		-e '/^ensure_time$/ s|^|curl http://metadata.packet.net/bundle.pem \| tee /tmp/caddy-cert.pem\n|' \
 		-e '/curl.*https:\/\/metadata.packet.net/ s|curl|curl --cacert /tmp/caddy-cert.pem|' \
 		-e '/^\s*reboot$/ s|reboot|poweroff|' \
 		-e 's|\./cleanup.sh.*|poweroff|' \

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -348,8 +348,8 @@ do_test() {
 	# 1. do not verify https cert for metadata.packet.net since we dont want to add real cert here
 	# 2. poweroff instead of reboot after install
 	sed -i \
+		-e '/^ensure_time$/ s|^|curl http://metadata.packet.net/bundle.pem >/tmp/caddy-cert.pem\n|' \
 		-e '/curl.*https:\/\/metadata.packet.net/ s|curl|curl --cacert /tmp/caddy-cert.pem|' \
-		-e '/^hardware_id=/ s|^|curl http://metadata.packet.net/bundle.pem >/tmp/caddy-cert.pem\n|' \
 		-e '/^\s*reboot$/ s|reboot|poweroff|' \
 		-e 's|\./cleanup.sh.*|poweroff|' \
 		osie-installer.sh runner.sh

--- a/installer/osie-installer.sh
+++ b/installer/osie-installer.sh
@@ -17,7 +17,7 @@ fail() {
 ensure_time() {
 	local d hwdate mddate month
 	local months='jan feb mar apr may jun jul aug sep oct nov dec'
-	d=$(curl -sI http://metadata.packet.net/metadata | sed -n '/^Date:/ s|Date: ||p')
+	d=$(curl -sI https://metadata.packet.net/metadata | sed -n '/^Date:/ s|Date: ||p')
 	# shellcheck disable=SC2018 disable=SC2019
 	month=$(echo "$d" | awk '{print $3}' | tr 'A-Z' 'a-z')
 	local i=1

--- a/installer/osie-installer.sh
+++ b/installer/osie-installer.sh
@@ -17,7 +17,7 @@ fail() {
 ensure_time() {
 	local d hwdate mddate month
 	local months='jan feb mar apr may jun jul aug sep oct nov dec'
-	d=$(curl -sI https://metadata.packet.net/metadata | sed -n '/^Date:/ s|Date: ||p')
+	d=$(curl -vI https://metadata.packet.net/metadata | tee /dev/stderr | sed -n '/^Date:/ s|Date: ||p')
 	# shellcheck disable=SC2018 disable=SC2019
 	month=$(echo "$d" | awk '{print $3}' | tr 'A-Z' 'a-z')
 	local i=1
@@ -43,6 +43,7 @@ ensure_time() {
 }
 
 set -o errexit -o pipefail
+set -x
 
 # Create OSIE motd
 cat <<'EOF' >/etc/motd


### PR DESCRIPTION
Metadata is looked up with https later in the script anyway so if https
fails it will now just fail sooner. This is needed for new deployments
where we are having issues with metadata on http.
