### PR TITLE
.github: drop, in favor of the org's .github repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-- [ ] Changelog updated


### PR DESCRIPTION
## Description

Drop the old PR template in favor of the .github org-level PR template.

## Why is this needed

The one in this repo was pretty slim, and I think the new one covers the important topics a bit better.

## How Has This Been Tested?

- [x] Submitted this PR
- [ ] It will have been tested if it merges (todo: tick this box after merging)

## How are existing users impacted? What migration steps/scripts do we need?

None, though future contributions will request a more verbose PR body.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required) (not required)
- [x] added unit or e2e tests (not required)
- [x] provided instructions on how to upgrade (not required)
