### PR TITLE
Remove baremetal_2a5 from exclusion list.

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -216,7 +216,7 @@ fi
 
 # Call firmware script to update components and firmware
 case "$class" in
-baremetal_2a2 | baremetal_2a4 | baremetal_2a5 | baremetal_hua)
+baremetal_2a2 | baremetal_2a4 | baremetal_hua)
 	echo "skipping hardware update for oddball aarch64s"
 	;;
 *)


### PR DESCRIPTION
## Description

It seems previously this plan type wasn't able to report it's component 
information, I tested several machines manually and this seems safe to 
remove

## Why is this needed

Information about our server's hardware is important

## How Has This Been Tested?

Deployed custom OSIE via userdata and confirmed this server type reports back into our system properly

## How are existing users impacted? What migration steps/scripts do we need?

No impact expected
