### PR TITLE
Add try except for get_nvme_attributes

### DIFF
--- a/docker/scripts/hardware/utils.py
+++ b/docker/scripts/hardware/utils.py
@@ -120,8 +120,14 @@ def get_smart_devices():
 
 
 def get_nvme_attributes(device):
-    smartctl_json = cmd_output("smartctl", "--all", "--json", device)
-    return json.loads(smartctl_json)["nvme_smart_health_information_log"]
+    try:
+        smartctl_json = cmd_output("smartctl", "--all", "--json", device)
+        return json.loads(smartctl_json)["nvme_smart_health_information_log"]
+    except Exception:
+        print(
+            "\n\n !! Garbage data received, suspected ancient smartctl, upgrade suggested !! \n\n"
+        )
+        return
 
 
 def get_smart_attributes(device):


### PR DESCRIPTION
## Description

Lets try to gather the NVMe SMART information, but if for some reason we 
get an exception error, return nothing instead of crashing.

## Why is this needed

Sometimes things go wrong and we should try to account for that.

## How Has This Been Tested?
Executed on test system

## How are existing users impacted? What migration steps/scripts do we need?
Should prevent future de-provisioning issues
