### PR TITLE
Alpine 3.12

### DIFF
--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -43,9 +43,9 @@ RUN mkdir -p /etc/apk/cache && \
 USER builder
 WORKDIR /home/builder
 
-ENV COMMIT bb52b0d3f60cd75197ef218362f193378dfd869d
-ENV FLAVOR vanilla
-ENV KERNEL 4.14.55
+ENV COMMIT 69b95a3d1dd1627416f45bcbfb93c6f2d5f0d68b
+ENV FLAVOR lts
+ENV KERFNEL 5.4.52
 ENV MAKEFLAGS -j$(($(nproc) * 2))
 # make sure PKGREL is +1 what is in APKGBUILD
 ENV PKGREL 1

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -53,11 +53,10 @@ RUN true && \
     # Setup self-signed keys to sign the built packages \
     abuild-keygen -a -i -n && \
     # Fetch alpine package tree \
-    git clone -b master https://github.com/alpinelinux/aports && \
-    cd aports && \
-    git checkout $COMMIT && \
+    curl -fL https://github.com/alpinelinux/aports/archive/$COMMIT.tar.gz | tar -zxf - && \
+    mv aports-$COMMIT aports
     # Build customized linux-$FLAVOR package \
-    cd main/linux-$FLAVOR && \
+    cd aports/main/linux-$FLAVOR && \
     sed -i APKBUILD \
         -e 's/silentoldconfig/olddefconfig/g' \
 	-e "/^pkgrel=/ s/=.*/$PKGREL/" && \

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -58,17 +58,7 @@ RUN sed -i 's/silentoldconfig/olddefconfig/g' APKBUILD && \
     abuild clean
 
 USER root
-# RUN apk add --no-scripts --no-cache --update --upgrade /home/builder/packages/main/x86_64/linux-vanilla*.apk
 RUN apk add --no-scripts --update --upgrade /home/builder/packages/main/x86_64/linux-vanilla*.apk
-
-# ADD https://www.kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.17.tar.gz .
-
-# RUN zcat kexec-tools-2.0.17.tar.gz | tar xvf - && \
-#   cd kexec-tools-2.0.17 && \
-#   sed 's/loff_t/off_t/g' -i vmcore-dmesg/vmcore-dmesg.c && \
-#   ./configure && \
-#   make && \
-#   make install
 
 ARG ECLYPSIUM_DRIVER_VERSION=2.0.0
 ARG ECLYPSIUM_DRIVER_SHA512=b9cfebc3b0abd834d73f025f925d896bea8d9dac2a3c3605980a94a35cd188db159ca165e5884863f5bd4a94d39861ecdf998cf8e99ea89d6f093a7bc64b5347
@@ -80,9 +70,6 @@ WORKDIR /home/builder
 
 ENV FLAVOR vanilla
 # Download the eclypsium driver abuild and build it
-# we force it to build for a vanilla kernel of a specific version with the sed(s) below
-# sed -i 's/4\.9\.65/4.14.34/g' APKBUILD && \
-# sed -i 's/\tmake/make kernel-src-dir="\/lib\/modules\/4.14.34-0-vanilla\/build" machine="x86_64"/' APKBUILD && \
 RUN echo "${ECLYPSIUM_DRIVER_SHA512}  ${ECLYPSIUM_DRIVER_FILENAME}" | sha512sum -c && \
     tar -zxvf ${ECLYPSIUM_DRIVER_FILENAME} && \
     cd aports/non-free/eclypsiumdriver && \

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -43,22 +43,30 @@ RUN mkdir -p /etc/apk/cache && \
 USER builder
 WORKDIR /home/builder
 
+ENV COMMIT bb52b0d3f60cd75197ef218362f193378dfd869d
+ENV FLAVOR vanilla
+ENV KERNEL 4.14.55
+# make sure PKGREL is +1 what is in APKGBUILD
+ENV PKGREL 1
+
 RUN true && \
     # Setup self-signed keys to sign the built packages \
     abuild-keygen -a -i -n && \
     # Fetch alpine package tree \
     git clone -b master https://github.com/alpinelinux/aports && \
     cd aports && \
-    git checkout bb52b0d3f60cd75197ef218362f193378dfd869d && \
-    # Build customized linux-vanilla package \
-    cd main/linux-vanilla && \
-    sed -i 's/silentoldconfig/olddefconfig/g' APKBUILD && \
-    echo 'CONFIG_KEXEC=y' >> config-vanilla.x86_64 && \
+    git checkout $COMMIT && \
+    # Build customized linux-$FLAVOR package \
+    cd main/linux-$FLAVOR && \
+    sed -i APKBUILD \
+        -e 's/silentoldconfig/olddefconfig/g' \
+	-e "/^pkgrel=/ s/=.*/$PKGREL/" && \
+    echo 'CONFIG_KEXEC=y' >> config-$FLAVOR.x86_64 && \
     abuild checksum && \
     abuild -r && \
     abuild clean && \
     # Install the customized linux-vanilla package \
-    sudo apk add --no-scripts --update --upgrade /home/builder/packages/main/x86_64/linux-vanilla*.apk
+    sudo apk add --no-scripts --update --upgrade /home/builder/packages/main/x86_64/linux-$FLAVOR*.apk
 
 ARG ECLYPSIUM_DRIVER_VERSION=2.0.0
 ARG ECLYPSIUM_DRIVER_SHA512=b9cfebc3b0abd834d73f025f925d896bea8d9dac2a3c3605980a94a35cd188db159ca165e5884863f5bd4a94d39861ecdf998cf8e99ea89d6f093a7bc64b5347
@@ -66,13 +74,14 @@ ARG ECLYPSIUM_DRIVER_FILENAME=eclypsiumdriver-alpine-${ECLYPSIUM_DRIVER_VERSION}
 
 COPY ${ECLYPSIUM_DRIVER_FILENAME} /home/builder/
 
-ENV FLAVOR vanilla
 # Download the eclypsium driver abuild and build it
 RUN echo "${ECLYPSIUM_DRIVER_SHA512}  ${ECLYPSIUM_DRIVER_FILENAME}" | sha512sum -c && \
     tar -zxvf ${ECLYPSIUM_DRIVER_FILENAME} && \
     cd aports/non-free/eclypsiumdriver && \
-    sed -i 's/_kpkgrel=1/_kpkgrel=0/' APKBUILD && \
-    sed -i 's/5\.4\.12/4.14.55/g' APKBUILD && \
+    sed -i APKBUILD \
+        -e "/^_kver=/ s/=.*/=$KERNEL/" \
+        -e "/^_kpkgrel=/ s/=*/=$PKGREL/" \
+        && \
     abuild checksum && \
     abuild -r
 

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -61,6 +61,13 @@ RUN true && \
     sed -i APKBUILD \
         -e 's/silentoldconfig/olddefconfig/g' \
 	-e "/^pkgrel=/ s/=.*/$PKGREL/" && \
+    # we only want to build the config-lts.x86_64 kernel, so we need remove to any lines that look like config.*x86_64 but is not config-lts.x86_46 \
+    # explanation: \
+    #   /config.*x86_64/! p :: if line does *not* match config.*x86_64 print it \
+    #   /config.*x86_64/ { ... } :: apply sub expression only for lines that match the pattern (so everything not ^ ) \
+    #   /config-lts.x86_64/ p :: for the config-lts.x86_64 lines print it \
+    sed -i APKBUILD -n \
+        -e '/config.*x86_64/! p; /config.*x86_64/ { /config-lts.x86_64/ p }' && \
     echo 'CONFIG_KEXEC=y' >> config-$FLAVOR.x86_64 && \
     abuild checksum && \
     abuild -r && \

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.7
+FROM alpine:3.12
 
-ENTRYPOINT /build.sh
+ENTRYPOINT [ "/build.sh" ]
 VOLUME /assets
 
 COPY qemu-aarch64-static /usr/bin/
@@ -20,7 +20,7 @@ RUN mkdir -p /etc/apk/cache && \
         && \
     apk add --no-scripts --update --upgrade --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
         kexec-tools \
-	&& \
+        && \
     apk cache sync && \
     mv /etc/apk/cache /cache && \
     apk add --no-scripts --no-cache --update --upgrade \
@@ -30,12 +30,8 @@ RUN mkdir -p /etc/apk/cache && \
         busybox-initscripts \
         coreutils \
         linux-headers \
+	sudo \
         && \
-    # remove edge when linux-vanilla is > 4.14.8 and has the nfp driver enabled,
-    # likely alpine v3.8
-    apk add --no-scripts --no-cache --update --upgrade --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        linux-firmware \
-	&& \
     adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder && \
     echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
     apk update
@@ -45,8 +41,8 @@ WORKDIR /home/builder
 
 ENV COMMIT 69b95a3d1dd1627416f45bcbfb93c6f2d5f0d68b
 ENV FLAVOR lts
-ENV KERFNEL 5.4.52
-ENV MAKEFLAGS -j$(($(nproc) * 2))
+ENV KERNEL 5.4.52
+ENV MAKEFLAGS -j4
 # make sure PKGREL is +1 what is in APKGBUILD
 ENV PKGREL 1
 
@@ -55,12 +51,21 @@ RUN true && \
     abuild-keygen -a -i -n && \
     # Fetch alpine package tree \
     curl -fL https://github.com/alpinelinux/aports/archive/$COMMIT.tar.gz | tar -zxf - && \
-    mv aports-$COMMIT aports
+    mv aports-$COMMIT aports && \
+    # Good to always have updated firmware
+    cd aports/main/linux-firmware && \
+    abuild checksum && \
+    abuild -r && \
+    abuild clean && \
+    ls /home/builder/packages/main/x86_64/linux-firmware*.apk && \
+    echo about to install && \
+    sudo apk add --no-scripts --update --upgrade /home/builder/packages/main/x86_64/linux-firmware*.apk && \
+    cd ../../.. && \
     # Build customized linux-$FLAVOR package \
     cd aports/main/linux-$FLAVOR && \
     sed -i APKBUILD \
         -e 's/silentoldconfig/olddefconfig/g' \
-	-e "/^pkgrel=/ s/=.*/$PKGREL/" && \
+	-e "/^pkgrel=/ s/=.*/=$PKGREL/" && \
     # we only want to build the config-lts.x86_64 kernel, so we need remove to any lines that look like config.*x86_64 but is not config-lts.x86_46 \
     # explanation: \
     #   /config.*x86_64/! p :: if line does *not* match config.*x86_64 print it \
@@ -69,11 +74,14 @@ RUN true && \
     sed -i APKBUILD -n \
         -e '/config.*x86_64/! p; /config.*x86_64/ { /config-lts.x86_64/ p }' && \
     echo 'CONFIG_KEXEC=y' >> config-$FLAVOR.x86_64 && \
+    echo 'CONFIG_IONIC=y' >> config-$FLAVOR.x86_64 && \
     abuild checksum && \
     abuild -r && \
     abuild clean && \
     # Install the customized linux-vanilla package \
     sudo apk add --no-scripts --update --upgrade /home/builder/packages/main/x86_64/linux-$FLAVOR*.apk
+
+RUN ls /home/builder/packages/main/x86_64/linux-*.apk
 
 ARG ECLYPSIUM_DRIVER_VERSION=2.0.0
 ARG ECLYPSIUM_DRIVER_SHA512=b9cfebc3b0abd834d73f025f925d896bea8d9dac2a3c3605980a94a35cd188db159ca165e5884863f5bd4a94d39861ecdf998cf8e99ea89d6f093a7bc64b5347
@@ -87,11 +95,12 @@ RUN echo "${ECLYPSIUM_DRIVER_SHA512}  ${ECLYPSIUM_DRIVER_FILENAME}" | sha512sum 
     cd aports/non-free/eclypsiumdriver && \
     sed -i APKBUILD \
         -e "/^_kver=/ s/=.*/=$KERNEL/" \
-        -e "/^_kpkgrel=/ s/=*/=$PKGREL/" \
+        -e "/^_kpkgrel=/ s/=.*/=$PKGREL/" \
         && \
     abuild checksum && \
     abuild -r && \
     abuild clean && \
+    sudo apk add --no-scripts --no-cache --update --upgrade /home/builder/packages/non-free/x86_64/eclypsium*.apk
 
 USER root
 RUN sudo mv /cache /etc/apk/cache

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -5,8 +5,8 @@ VOLUME /assets
 
 COPY qemu-aarch64-static /usr/bin/
 
-RUN mkdir -p /etc/apk/cache
-RUN apk add --update --upgrade \
+RUN mkdir -p /etc/apk/cache && \
+    apk add --update --upgrade \
         alpine-base \
         curl \
         docker \
@@ -17,56 +17,54 @@ RUN apk add --update --upgrade \
         openssh \
         squashfs-tools \
         tcpdump \
-        ;
-RUN apk cache sync
-RUN mv /etc/apk/cache /cache
-RUN apk add --no-scripts --no-cache --update --upgrade \
+        && \
+    apk add --no-scripts --update --upgrade --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        kexec-tools \
+	&& \
+    apk cache sync && \
+    mv /etc/apk/cache /cache && \
+    apk add --no-scripts --no-cache --update --upgrade \
         abuild \
         alpine-sdk \
         build-base \
         busybox-initscripts \
         coreutils \
         linux-headers \
-        ;
-
-# remove edge when linux-vanilla is > 4.14.8 and has the nfp driver enabled,
-# likely alpine v3.8
-RUN apk add --no-scripts --no-cache --update --upgrade --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        && \
+    # remove edge when linux-vanilla is > 4.14.8 and has the nfp driver enabled,
+    # likely alpine v3.8
+    apk add --no-scripts --no-cache --update --upgrade --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
         linux-firmware \
-        ;
-
-RUN adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder && \
+	&& \
+    adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder && \
     echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
     apk update
 
 USER builder
 WORKDIR /home/builder
 
-# Setup some self-signed keys and grab alpine package tree
-RUN abuild-keygen -a -i -n && \
+RUN true && \
+    # Setup self-signed keys to sign the built packages \
+    abuild-keygen -a -i -n && \
+    # Fetch alpine package tree \
     git clone -b master https://github.com/alpinelinux/aports && \
     cd aports && \
-    git checkout bb52b0d3f60cd75197ef218362f193378dfd869d
-
-# Build customized linux-vanilla
-WORKDIR /home/builder/aports/main/linux-vanilla
-
-RUN sed -i 's/silentoldconfig/olddefconfig/g' APKBUILD && \
+    git checkout bb52b0d3f60cd75197ef218362f193378dfd869d && \
+    # Build customized linux-vanilla package \
+    cd main/linux-vanilla && \
+    sed -i 's/silentoldconfig/olddefconfig/g' APKBUILD && \
     echo 'CONFIG_KEXEC=y' >> config-vanilla.x86_64 && \
     abuild checksum && \
     abuild -r && \
-    abuild clean
-
-USER root
-RUN apk add --no-scripts --update --upgrade /home/builder/packages/main/x86_64/linux-vanilla*.apk
+    abuild clean && \
+    # Install the customized linux-vanilla package \
+    sudo apk add --no-scripts --update --upgrade /home/builder/packages/main/x86_64/linux-vanilla*.apk
 
 ARG ECLYPSIUM_DRIVER_VERSION=2.0.0
 ARG ECLYPSIUM_DRIVER_SHA512=b9cfebc3b0abd834d73f025f925d896bea8d9dac2a3c3605980a94a35cd188db159ca165e5884863f5bd4a94d39861ecdf998cf8e99ea89d6f093a7bc64b5347
 ARG ECLYPSIUM_DRIVER_FILENAME=eclypsiumdriver-alpine-${ECLYPSIUM_DRIVER_VERSION}.tgz
 
 COPY ${ECLYPSIUM_DRIVER_FILENAME} /home/builder/
-USER builder
-WORKDIR /home/builder
 
 ENV FLAVOR vanilla
 # Download the eclypsium driver abuild and build it
@@ -79,9 +77,6 @@ RUN echo "${ECLYPSIUM_DRIVER_SHA512}  ${ECLYPSIUM_DRIVER_FILENAME}" | sha512sum 
     abuild -r
 
 USER root
-
-RUN mv /cache /etc/apk/cache
-
-RUN apk add --no-scripts --update --upgrade --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing kexec-tools
+RUN sudo mv /cache /etc/apk/cache
 
 COPY build.sh /build.sh

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -7,33 +7,33 @@ COPY qemu-aarch64-static /usr/bin/
 
 RUN mkdir -p /etc/apk/cache
 RUN apk add --update --upgrade \
-    alpine-base \
-    curl \
-    docker \
-    jq \
-    mdadm \
-    mkinitfs \
-    musl-utils \
-    openssh \
-    squashfs-tools \
-    tcpdump \
-    ;
+        alpine-base \
+        curl \
+        docker \
+        jq \
+        mdadm \
+        mkinitfs \
+        musl-utils \
+        openssh \
+        squashfs-tools \
+        tcpdump \
+        ;
 RUN apk cache sync
 RUN mv /etc/apk/cache /cache
 RUN apk add --no-scripts --no-cache --update --upgrade \
-    abuild \
-    alpine-sdk \
-    build-base \
-    busybox-initscripts \
-    coreutils \
-    linux-headers \
-    ;
+        abuild \
+        alpine-sdk \
+        build-base \
+        busybox-initscripts \
+        coreutils \
+        linux-headers \
+        ;
 
 # remove edge when linux-vanilla is > 4.14.8 and has the nfp driver enabled,
 # likely alpine v3.8
 RUN apk add --no-scripts --no-cache --update --upgrade --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-    linux-firmware \
-    ;
+        linux-firmware \
+        ;
 
 RUN adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder && \
     echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -46,6 +46,7 @@ WORKDIR /home/builder
 ENV COMMIT bb52b0d3f60cd75197ef218362f193378dfd869d
 ENV FLAVOR vanilla
 ENV KERNEL 4.14.55
+ENV MAKEFLAGS -j$(($(nproc) * 2))
 # make sure PKGREL is +1 what is in APKGBUILD
 ENV PKGREL 1
 
@@ -82,7 +83,8 @@ RUN echo "${ECLYPSIUM_DRIVER_SHA512}  ${ECLYPSIUM_DRIVER_FILENAME}" | sha512sum 
         -e "/^_kpkgrel=/ s/=*/=$PKGREL/" \
         && \
     abuild checksum && \
-    abuild -r
+    abuild -r && \
+    abuild clean && \
 
 USER root
 RUN sudo mv /cache /etc/apk/cache

--- a/installer/alpine/Makefile
+++ b/installer/alpine/Makefile
@@ -38,6 +38,7 @@ endif
 qemu-aarch64-static:
 	$(E) "GET   $@"
 	$(Q) wget -q https://github.com/multiarch/qemu-user-static/releases/download/v2.9.1-1/$@
+	$(Q) chmod 755 $@
 
 /proc/sys/fs/binfmt_misc/qemu-aarch64:
 	$(E) 'You need to configure qemu-aarch64-static for aarch64 programs, for example:'

--- a/installer/alpine/Makefile
+++ b/installer/alpine/Makefile
@@ -29,10 +29,15 @@ osie-alpine-initramfs-builder-x86_64: Dockerfile build.sh qemu-aarch64-static
 	$(E) "IMAGE $@"
 	$(Q) docker build -f Dockerfile -t $@ . 1>$o 2>$e
 	$(Q) touch $@
+ifeq ($(CI),drone)
+	$(Q) mkdir -p /tmp/$${DRONE_BUILD_NUMBER}
+	$(Q) docker run -v /tmp/$${DRONE_BUILD_NUMBER}:/assets --name assets_$${DRONE_BUILD_NUMBER} $@
+	$(Q) docker rm -f assets_$${DRONE_BUILD_NUMBER}
+endif
 
 qemu-aarch64-static:
 	$(E) "GET   $@"
-	$(Q) wget -qN https://github.com/multiarch/qemu-user-static/releases/download/v2.9.1-1/$@
+	$(Q) wget -q https://github.com/multiarch/qemu-user-static/releases/download/v2.9.1-1/$@
 
 /proc/sys/fs/binfmt_misc/qemu-aarch64:
 	$(E) 'You need to configure qemu-aarch64-static for aarch64 programs, for example:'

--- a/installer/alpine/build.sh
+++ b/installer/alpine/build.sh
@@ -5,41 +5,50 @@ set -o errexit -o nounset -o pipefail -o xtrace
 # shellcheck disable=SC2039
 [[ $(uname -m) == aarch64 ]] && echo "aarch64 isn't _really_ tested/supported yet" && exit 1
 
-# Install the eclypsiumdriver package previously built in the Dockerfile
-apk add --no-scripts --no-cache --update --upgrade /home/builder/packages/non-free/x86_64/eclypsium*.apk
+build_initramfs() {
+	# Eclypsium driver and supporting modules (IPMI)
+	cat >/etc/mkinitfs/features.d/eclypsium.modules <<-EOF
+		extra/eclypsiumdriver.ko
+		kernel/drivers/char/ipmi/*.ko
+	EOF
 
-# Eclypsium driver and supporting modules (IPMI)
-cat >/etc/mkinitfs/features.d/eclypsium.modules <<EOF
-extra/eclypsiumdriver.ko
-kernel/drivers/char/ipmi/*.ko
-EOF
+	cat >/etc/mkinitfs/features.d/network.modules <<-EOF
+		kernel/drivers/net/ethernet
+		kernel/net/packet/af_packet.ko
+	EOF
 
-cat >/etc/mkinitfs/features.d/network.modules <<EOF
-kernel/drivers/net/ethernet
-kernel/net/packet/af_packet.ko
-EOF
+	cat >/etc/mkinitfs/features.d/packetrepo.files <<-EOF
+		/etc/apk/cache/*
+	EOF
 
-cat >/etc/mkinitfs/features.d/packetrepo.files <<EOF
-/etc/apk/cache/*
-EOF
+	cat <<-EOF | sort -u >/etc/mkinitfs/features.d/virtio.modules.tmp
+		$(cat /etc/mkinitfs/features.d/virtio.modules)
+		kernel/drivers/char/hw_random/virtio-rng.ko
+	EOF
+	mv /etc/mkinitfs/features.d/virtio.modules.tmp /etc/mkinitfs/features.d/virtio.modules
 
-cat <<EOF | sort -u >/etc/mkinitfs/features.d/virtio.modules.tmp
-$(cat /etc/mkinitfs/features.d/virtio.modules)
-kernel/drivers/char/hw_random/virtio-rng.ko
-EOF
-mv /etc/mkinitfs/features.d/virtio.modules.tmp /etc/mkinitfs/features.d/virtio.modules
+	# Make initramfs with features we think are spiffy
+	# shellcheck disable=SC2016
+	echo 'features="base ext2 ext3 ext4 keymap network packetrepo squashfs virtio eclypsium"' >/etc/mkinitfs/mkinitfs.conf
+	kver=$(basename /lib/modules/*)
+	mkinitfs -l "$kver"
+	mkinitfs -o /assets/initramfs "$kver"
+}
 
-# Make initramfs with features we think are spiffy
-# shellcheck disable=SC2016
-echo 'features="base ext2 ext3 ext4 keymap network packetrepo squashfs virtio eclypsium"' >/etc/mkinitfs/mkinitfs.conf
-kver=$(basename /lib/modules/*)
-mkinitfs -l "$kver"
-mkinitfs -o /assets/initramfs-$FLAVOR "$kver"
+build_modloop() {
+	mkdir -p modloop/
+	cp -a /lib/modules/ modloop/
+	cp -a /lib/firmware/ modloop/modules
+	mksquashfs modloop/ /assets/modloop -b 1048576 -comp xz -Xdict-size 100% -noappend
+}
 
-cp /boot/vmlinuz-$FLAVOR /assets/vmlinuz-$FLAVOR
+build_vmlinuz() {
+	cp /boot/vmlinuz-$FLAVOR /assets/vmlinuz
+}
 
-# Make a new modloop
-mkdir -p modloop/
-cp -a /lib/modules/ modloop/
-cp -a /lib/firmware/ modloop/modules
-mksquashfs modloop/ /assets/modloop-$FLAVOR -b 1048576 -comp xz -Xdict-size 100% -noappend
+case $1 in
+vmlinuz) build_vmlinuz ;;
+initramfs) build_initramfs ;;
+modloop) build_modloop ;;
+*) echo "unknown argument: $1" >&2 && exit 1 ;;
+esac

--- a/installer/alpine/build.sh
+++ b/installer/alpine/build.sh
@@ -34,12 +34,12 @@ mv /etc/mkinitfs/features.d/virtio.modules.tmp /etc/mkinitfs/features.d/virtio.m
 echo 'features="base ext2 ext3 ext4 keymap network packetrepo squashfs virtio eclypsium"' >/etc/mkinitfs/mkinitfs.conf
 kver=$(basename /lib/modules/*)
 mkinitfs -l "$kver"
-mkinitfs -o /assets/initramfs-vanilla "$kver"
+mkinitfs -o /assets/initramfs-$FLAVOR "$kver"
 
-cp /boot/vmlinuz-vanilla /assets/vmlinuz-vanilla
+cp /boot/vmlinuz-$FLAVOR /assets/vmlinuz-$FLAVOR
 
 # Make a new modloop
 mkdir -p modloop/
 cp -a /lib/modules/ modloop/
 cp -a /lib/firmware/ modloop/modules
-mksquashfs modloop/ /assets/modloop-vanilla -b 1048576 -comp xz -Xdict-size 100% -noappend
+mksquashfs modloop/ /assets/modloop-$FLAVOR -b 1048576 -comp xz -Xdict-size 100% -noappend

--- a/installer/alpine/init-x86_64
+++ b/installer/alpine/init-x86_64
@@ -20,6 +20,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 # basic mounts
 mount -t proc -o noexec,nosuid,nodev proc /proc
 mount -t sysfs -o noexec,nosuid,nodev sysfs /sys
+mount -t cgroup -o all cgroup /sys/fs/cgroup
 
 # some helpers
 ebegin() {

--- a/osie-runner/.dockerignore
+++ b/osie-runner/.dockerignore
@@ -1,3 +1,5 @@
 Dockerfile*
 requirements.in
 __pycache__
+Tupfile
+osie-runner*.tar.gz

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -1,5 +1,6 @@
+# vim: set filetype=make :
 alpine_version_aarch64 := 3.4
-alpine_version_x86_64 := 3.7
+alpine_version_x86_64 := 3.12
 
 arches := aarch64 x86_64
 x86s := x86_64
@@ -176,7 +177,7 @@ build/osie-test-env: ci/Dockerfile
 	touch $@
 
 {% for arch in platforms.values() | unique | sort -%}
-test-{{arch}}: $(cprs) build/osie-test-env package-apps package-grubs build/$v/osie-{{arch}}.tar.gz build/$v/osie-runner-{{arch}}.tar.gz build/$v/repo-{{arch}} ${packaged-{{arch}}} ci/ifup.sh ci/vm.sh build/$v/test-initramfs-{{arch}}/test-initramfs
+test-{{arch}}: $(cprs) build/osie-test-env package-apps package-grubs build/$v/osie-{{arch}}.tar.gz build/$v/osie-runner-{{arch}}.tar.gz build/$v/repo-{{arch}} ${packaged-{{arch}}} ci/ifup.sh ci/vm.sh build/$v/test-initramfs-{{arch}}/test-initramfs {%- if arch == "aarch64" %} /proc/sys/fs/binfmt_misc/qemu-aarch64{% endif %}
 	$(E)"DOCKER   $@"
 ifneq ($(CI),drone)
 	$(Q)docker run --rm -ti \
@@ -220,8 +221,9 @@ else
 	ci/vm.sh network_test | tee build/$@.log >/dev/$T
 endif
 
+build/osie-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64
 build/osie-aarch64.tar.gz: SED=/FROM/ s|.*|FROM multiarch/ubuntu-debootstrap:arm64-xenial|
-build/osie-x86_64.tar.gz: SED=
+build/osie-x86_64.tar.gz:  SED=
 build/osie-%.tar.gz: docker/Dockerfile ${osiesrcs}
 	$(E)"DOCKER   $@"
 	$(Q)sed '${SED}' $< > $<.$*
@@ -229,8 +231,9 @@ build/osie-%.tar.gz: docker/Dockerfile ${osiesrcs}
 	$(Q)docker save osie:$* > $@.tmp
 	$(Q)mv $@.tmp $@
 
+build/osie-runner-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64
 build/osie-runner-aarch64.tar.gz: SED=/FROM/ s|.*|FROM multiarch/alpine:arm64-v3.7|
-build/osie-runner-x86_64.tar.gz: SED=
+build/osie-runner-x86_64.tar.gz:  SED=
 build/osie-runner-%.tar.gz: osie-runner/Dockerfile $(shell git ls-files osie-runner)
 	$(E)"DOCKER   $@"
 	$(Q)sed '${SED}' $< > $<.$*
@@ -264,3 +267,37 @@ build/initramfs-{{platform}} build/modloop-{{platform}} build/vmlinuz-{{platform
 	$(E)"LN       $@"
 	$(Q)ln -nsf ../$< $@
 {% endfor -%}
+
+assets-aarch64: installer/alpine/assets-aarch64/initramfs installer/alpine/assets-aarch64/modloop installer/alpine/assets-aarch64/vmlinuz
+build/osie-alpine-initramfs-builder-aarch64: installer/alpine/Dockerfile installer/alpine/build.sh installer/alpine/eclypsiumdriver-alpine-* installer/alpine/qemu-aarch64-static /proc/sys/fs/binfmt_misc/qemu-aarch64
+	$(E)"IMAGE $@"
+	$(Q)sed '/^FROM alpine/ s| .*| arm64v8/alpine:3.6|' installer/alpine/Dockerfile > installer/alpine/Dockerfile.aarch64
+	$(Q)docker build -f installer/alpine/Dockerfile.aarch64 -t $@ installer/alpine/ 2>&1 | tee $@.log >/dev/$T
+	$(Q)touch $@
+
+assets-x86_64: installer/alpine/assets-x86_64/initramfs installer/alpine/assets-x86_64/modloop installer/alpine/assets-x86_64/vmlinuz
+build/osie-alpine-initramfs-builder-x86_64:  installer/alpine/Dockerfile installer/alpine/build.sh installer/alpine/eclypsiumdriver-alpine-* installer/alpine/qemu-aarch64-static
+	$(E)"IMAGE $@"
+	$(Q)docker build -f installer/alpine/Dockerfile -t $@ installer/alpine/ 2>&1 | tee $@.log >/dev/$T
+	$(Q)touch $@
+ifeq ($(CI),drone)
+	$(Q)mkdir -p /tmp/$${DRONE_BUILD_NUMBER}
+	$(Q)docker run -v /tmp/$${DRONE_BUILD_NUMBER}:/assets --name assets_$${DRONE_BUILD_NUMBER} $@
+	$(Q)docker rm -f assets_$${DRONE_BUILD_NUMBER}
+endif
+installer/alpine/assets-x86_64/initramfs installer/alpine/assets-x86_64/modloop installer/alpine/assets-x86_64/vmlinuz: build/osie-alpine-initramfs-builder-x86_64
+	$(E)"BUILD $@"
+	$(Q)docker run --rm -v ${PWD}/${@D}/:/assets/ --name=osie-assets-x86_64-${@F} $< ${@F} 2>&1 | tee build/osie-assets-x86_64-${@F}.log >/dev/$T
+
+installer/alpine/qemu-aarch64-static:
+	$(E)"GET   $@"
+	#$(Q)wget -v https://github.com/multiarch/qemu-user-static/releases/download/v5.0.0-2/$(@F) -O $@
+	$(Q)wget -v https://github.com/multiarch/qemu-user-static/releases/download/v2.9.1-1/$(@F) -O $@
+
+/proc/sys/fs/binfmt_misc/qemu-aarch64:
+	$(E)'You need to configure qemu-aarch64-static for aarch64 programs, for example:'
+	$(E)
+	$(E)'        docker run --rm --privileged multiarch/qemu-user-static:register --reset'
+	$(E)
+	$(E)'and can disable all binfmt with:'
+	$(E)


### PR DESCRIPTION
## Description

Update our x86_64 alpine to v3.12, upgrade kernel to latest lts (5.4.52) and add Pensando NIC drivers. Also lift the rules from installer/alpine/Makefile into rules.mk.j2 so that the top-level make can handle building the alpine files itself.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
