### PR TITLE
osie-runner: do not print exception tracebacks during hegel reconnects

### DIFF
--- a/osie-runner/run.py
+++ b/osie-runner/run.py
@@ -120,7 +120,6 @@ while True:
     try:
         resp = watch.next()
     except grpc.RpcError as e:
-        log.exception("grpc error")
         log.info("hegel went away, attempting to reconnect")
         while True:
             try:


### PR DESCRIPTION
When OSIE reconnects to hegel, an exception can be thrown and cause a
traceback to be displayed. This isn't really an error case and can cause
confusion for users trying to troubleshoot errors, so don't run the
exception logger, and rely on the info logger instead.

This is a fix for ENG-7075.