### PR TITLE
Gather a better Mellanox model, from partNumber

### DIFF
--- a/docker/scripts/hardware/component/network.py
+++ b/docker/scripts/hardware/component/network.py
@@ -56,6 +56,7 @@ class Network(Component):
                 self.firmware_version = utils.get_mellanox_prop(
                     self.pci_id, "firmware_version"
                 )
+                self.model = utils.get_mellanox_part_number(self.pci_id)
                 self.data["mellanox_psid"] = utils.get_mellanox_prop(
                     self.pci_id, "psid"
                 )

--- a/docker/scripts/hardware/utils.py
+++ b/docker/scripts/hardware/utils.py
@@ -253,6 +253,11 @@ def lspci(pci_id):
     return _lspci
 
 
+def get_mellanox_part_number(pci_id):
+    tree = etree.fromstring(mlxup_query(pci_id))
+    return tree[0].attrib["partNumber"]
+
+
 def get_mellanox_prop(pci_id, prop):
     regex = {
         "firmware_version": re.compile(r"^FW Version:\s*(.*)$", re.MULTILINE),


### PR DESCRIPTION
## Description

For our Mellanox cards, lets gather partNumber for the model

## Why is this needed

Since we aren't doing this currently and we're reporting back name and model as the same thing. This is needed to pin firmware based on model which currently doesn't reflect reality well enough to do so.

## How Has This Been Tested?
Tested with the inventory.py, successfully posted


## How are existing users impacted? What migration steps/scripts do we need?

No impact expected
