### PR TITLE
Added container name for worker

### DIFF
--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -58,7 +58,7 @@ rm -f /sbin/mdev
 
 mkdir /worker
 
-docker run --privileged -t \
+docker run --privileged -t --name "tink-worker" \
 	-e "container_uuid=$id" \
 	-e "WORKER_ID=$worker_id" \
 	-e "DOCKER_REGISTRY=$docker_registry" \


### PR DESCRIPTION
## Description

Container name was not provided for `tink-worker` container.

## Why is this needed

Fixes: #27 

## How Has This Been Tested?
I have varified the change by creating a `tink-worker` through vagrant.



