### PR TITLE
delay removing mdev until after images have been downloaded

### DIFF
--- a/apps/runner.sh
+++ b/apps/runner.sh
@@ -62,9 +62,6 @@ ______          _        _                _
 ##          Task Runner Environment          ##
 EOF
 
-# stop mdev from messing with us once and for all
-rm -f /sbin/mdev
-
 facility=$(sed -nr 's|.*\bfacility=(\S+).*|\1|p' /proc/cmdline)
 
 ensure_time
@@ -106,6 +103,9 @@ if ! docker images "osie:$arch" | grep osie >/dev/null; then
 		docker load |
 		tee
 fi
+
+# stop mdev from messing with us once and for all
+rm -f /sbin/mdev
 
 # make sure messages show up in all consoles
 # we skip first because it's already going there via stdout


### PR DESCRIPTION
We've seen a couple of plans run into an issue where they don't
discovery driver properly during initial preinstall. However during
deprovision it seems to find them every time.

This seems to be due to mdev getting removed too soon before it's had
time to discover everything. By putting the removal after loading the
docker images, it allows plenty of time for it to complete its scan.
