### PR TITLE
ci/test-network.sh: Correctly check subprocess return

### DIFF
--- a/ci/network-test-files/want/sci-c1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/sci-c1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/sci-c1.xlarge.x86-quanta/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/sci-c1.xlarge.x86-quanta/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/sci-c1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/sci-c1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/sci-m1.xlarge.x86-dell/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/sci-m1.xlarge.x86-dell/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/sci-m1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/sci-m1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/sci-t1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/sci-t1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/ub14-c1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/ub14-c1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/ub14-c1.xlarge.x86-quanta/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/ub14-c1.xlarge.x86-quanta/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/ub14-c1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/ub14-c1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/ub14-m1.xlarge.x86-dell/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/ub14-m1.xlarge.x86-dell/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/ub14-m1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/ub14-m1.xlarge.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/ub14-s1.large.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/ub14-s1.large.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"

--- a/ci/network-test-files/want/ub14-t1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
+++ b/ci/network-test-files/want/ub14-t1.small.x86-supermicro/etc/udev/rules.d/70-persistent-net.rules
@@ -4,7 +4,7 @@
 # line, and change only the value of the NAME= key.
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC0@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy0"
 
 # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="eth*", NAME="dummy1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="@MAC1@", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="dummy1"


### PR DESCRIPTION
## Description

Fix `test-packet-networking` test case.

## Why is this needed

Tests have been failing since before the open-sourcing :neutral_face: 

## How Has This Been Tested?
Ran the tests, failures actually failed.
Fixed the tests, no more failures and test is green.