### PR TITLE
osie-runner: Ensure userdata key always exists

### DIFF
--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -225,6 +225,7 @@ def cacher_to_metadata(j, tinkerbell):
             "ip_addresses": [],
             "operating_system_version": os,
             "storage": storage,
+            "userdata": None,
         }
 
     os = instance["operating_system_version"]


### PR DESCRIPTION
## Description

If no instance exists we synthesize the data from what we do have in cacher_to_metadta . Since there's no instance theres no userdata so we would not set anything. This is not how things work in production cases. Userdata is always present, it is just set to None if no userdata was set. This does not match the data seen in production. `None`ness is taken care of already in a previous PR, but it makes sense for cacher_to_metadata to try to match production as much as possible.

## Why is this needed

Makes cacher_to_metadata more closely resemble production instance case.

## How Has This Been Tested?

Matches production data, unit tests still pass.
