### PR TITLE
Re-enable xtrace for ease of debugging

### DIFF
--- a/apps/osie-installer.sh
+++ b/apps/osie-installer.sh
@@ -47,7 +47,7 @@ ensure_time() {
 	fi
 }
 
-set -o errexit -o pipefail
+set -o errexit -o pipefail -o xtrace
 set -x
 
 # Create OSIE motd

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit -o pipefail
+set -o errexit -o pipefail -o xtrace
 
 cmd=$1
 shift

--- a/docker/scripts/flavor-runner.sh
+++ b/docker/scripts/flavor-runner.sh
@@ -23,7 +23,7 @@ get_script() {
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
-	set -o errexit -o nounset -o pipefail
+	set -o errexit -o nounset -o pipefail -o xtrace
 	state=$(jq -r .state /statedir/metadata)
 	slug=$(jq -r .operating_system.slug /statedir/metadata)
 	script=$(get_script "$state" "$slug")

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -12,7 +12,7 @@ function init() {
 	BYELLOW='\033[0;33;5;7m'
 	NC='\033[0m' # No Color
 
-	set -o errexit -o pipefail
+	set -o errexit -o pipefail -o xtrace
 }
 
 function rainbow() {


### PR DESCRIPTION
We need some debugging improvements in OSIE immediately to troubleshoot some urgent issues. This PR simply re-enables bash xtrace in associated scripts, and as a later step we can make this contingent on custom userdata.