### PR TITLE
Fix userdata None in wants_custom_image

### DIFF
--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -311,7 +311,11 @@ def storage_differs(log, pre, instance):
 
 
 def wants_custom_image(log, pre, instance):
-    custom_repo_tag = get_custom_image_from_userdata(instance.get("userdata", ""))
+    userdata = instance.get("userdata", "")
+    if not userdata:
+        return False
+
+    custom_repo_tag = get_custom_image_from_userdata(userdata)
     pre_repo_tag = "https://github.com/packethost/packet-images#" + pre.get(
         "image_tag", ""
     )

--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -322,3 +322,5 @@ def wants_custom_image(log, pre, instance):
             preinstalled_repo_tag=pre_repo_tag,
         )
         return True
+
+    return False

--- a/osie-runner/test_handlers.py
+++ b/osie-runner/test_handlers.py
@@ -498,6 +498,7 @@ def test_wants_custom_osie(handler, instance, want):
     [
         ({}, {}, False),
         ({}, {"userdata": ""}, False),
+        ({}, {"userdata": None}, False),
         (
             {"image_tag": "image"},
             {
@@ -530,6 +531,7 @@ def test_wants_custom_osie(handler, instance, want):
     ids=[
         "empty instance",
         "userdata is empty",
+        "userdata is None",
         "userdata has same image_repo",
         "userdata has same image",
         "userdata has only different image_repo",

--- a/osie-runner/test_handlers.py
+++ b/osie-runner/test_handlers.py
@@ -1,6 +1,7 @@
 import copy
 import crypt
 import json
+import logging
 import os
 import re
 import stat
@@ -490,3 +491,52 @@ def test_existence_of_loop_sh(mocked_run_osie):
 )
 def test_wants_custom_osie(handler, instance, want):
     assert handler.wants_custom_osie(instance) == want
+
+
+@pytest.mark.parametrize(
+    "pre,instance,want",
+    [
+        ({}, {}, False),
+        ({}, {"userdata": ""}, False),
+        (
+            {"image_tag": "image"},
+            {
+                "userdata": "#image_repo=https://github.com/packet-images/packet-images.git"
+            },
+            False,
+        ),
+        ({"image_tag": "image"}, {"userdata": "#image_tag=image"}, False),
+        (
+            {"image_tag": "image"},
+            {"userdata": "#image_repo=https://github.com/somefork/packet-images.git"},
+            False,
+        ),
+        ({"image_tag": "image"}, {"userdata": "#image_tag=some-other-image"}, False),
+        (
+            {"image_tag": "image"},
+            {
+                "userdata": "#image_repo=https://github.com/somefork/packet-images.git\n#image_tag=image"
+            },
+            True,
+        ),
+        (
+            {"image_tag": "image"},
+            {
+                "userdata": "#image_repo=https://github.com/packet-images/packet-images.git\n#image_tag=some-other-image"
+            },
+            True,
+        ),
+    ],
+    ids=[
+        "empty instance",
+        "userdata is empty",
+        "userdata has same image_repo",
+        "userdata has same image",
+        "userdata has only different image_repo",
+        "userdata has only different image",
+        "userdata has different image_repo",
+        "userdata has different image",
+    ],
+)
+def test_wants_custom_image(pre, instance, want):
+    assert handlers.wants_custom_image(logging.getLogger(), pre, instance) == want


### PR DESCRIPTION
## Description

Missed a case where we need to check userdata being Falsy like in #82.

## Why is this needed

Affected production provisions from a preinstalled machine.

## How Has This Been Tested?

Traced down provisioning issue to this, verified missed a case of userdata == None and added unit tests.

## How are existing users impacted? What migration steps/scripts do we need?

No more failed provisions from preinstall state.

## Checklist:

I have:

- [x] added unit or e2e tests
