### PR TITLE
move early phone home to after install completes

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -97,11 +97,6 @@ else
 	custom_image=true
 fi
 
-# Phone home to tink NOW if non-packet custom image is used
-if [ "$early_phone" -eq 1 ]; then
-	phone_home "${tinkerbell}" '{"instance_id":"'"$(jq -r .id "$metadata")"'"}'
-fi
-
 target="/mnt/target"
 cprconfig=/tmp/config.cpr
 cprout=/statedir/cpr.json
@@ -552,6 +547,11 @@ phone_home "${tinkerbell}" '{"type":"provisioning.107"}'
 # Inform the API about installation complete
 phone_home "${tinkerbell}" '{"type":"provisioning.109"}'
 echo -e "${GREEN}#### Done${NC}"
+
+# Phone home to tink NOW if non-packet custom image is used
+if [ "$early_phone" -eq 1 ]; then
+	phone_home "${tinkerbell}" '{"instance_id":"'"$(jq -r .id "$metadata")"'"}'
+fi
 
 ## End installation
 etimer=$(date +%s)


### PR DESCRIPTION
custom images are phoning home too early and causing switch configs
to be modified too soon breaking network connectivity during the
preinstall. Moving this to after the install completes delays any
post network configuration from happening allowing the install to
complete.

Signed-off-by: Mike Mason <mason@packet.com>