### PR TITLE
Always re-DHCP during custom OS image installs

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -97,8 +97,12 @@ else
 	custom_image=true
 fi
 
-# Phone home to tink NOW if non-packet custom image is used
+# Phone home to tink NOW if non-packet custom image is used. We don't do this
+# later in case the custom OS image or url is bad, to ensure instance will be
+# preserved for the user to troubleshoot.
 if [ "$early_phone" -eq 1 ]; then
+	# Re-DHCP so we obtain an IP that will last beyond the early phone_home
+	reacquire_dhcp "$(ip_choose_if)"
 	phone_home "${tinkerbell}" '{"instance_id":"'"$(jq -r .id "$metadata")"'"}'
 fi
 


### PR DESCRIPTION
Without this, the early phone_home will mark the instance as activated,
and narwhal will remove the hardware IP address after a variable period
of time (typically less than a minute) at which point the provision will
fail because it can't download the image or phone_home to tinkerbell.