### PR TITLE
if ip_addresses is missing return an empty array

### DIFF
--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -236,7 +236,7 @@ def cacher_to_metadata(j, tinkerbell):
         "hostname": instance["hostname"],
         "id": instance["id"],
         "network": {
-            "addresses": instance["ip_addresses"],
+            "addresses": instance.get("ip_addresses", []),
             "bonding": {"mode": j["bonding_mode"]},
             "interfaces": [
                 {"bond": p["data"]["bond"], "mac": p["data"]["mac"], "name": p["name"]}


### PR DESCRIPTION
in some instances this may be empty if we're wanting the host to
simply wipe the disks and restart. This change keeps a KeyError
exception from being raised.