### PR TITLE
Add OS image retrieval provisioning event for preinstalls

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -532,6 +532,7 @@ EOF_ET
 else
 	./cpr.sh $cprconfig "$target" "$preserve_data" "$deprovision_fast" mount $cprout
 	phone_home "${tinkerbell}" '{"type":"provisioning.104"}'
+	phone_home "${tinkerbell}" '{"type":"provisioning.104.50"}'
 	phone_home "${tinkerbell}" '{"type":"provisioning.105"}'
 	phone_home "${tinkerbell}" '{"type":"provisioning.106"}'
 	phone_home "${tinkerbell}" '{"type":"provisioning.108"}'


### PR DESCRIPTION
During preinstalls, we issue many of the provisioning events whether
they are relevant or not so that the UI progress meter still moves
forward as in other cases. This adds the new 104.50 provisioning event
(OS image retrieved). Without this, that step of the progress meter
never turns green so it looks pretty awkward.

Signed-off-by: Scott Garman <sgarman@packet.com>