### PR TITLE
Add forgotten inventory argument

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -220,7 +220,7 @@ baremetal_2a2 | baremetal_2a4 | baremetal_hua)
 	echo "skipping hardware update for oddball aarch64s"
 	;;
 *)
-	packet-hardware --verbose --tinkerbell "${tinkerbell}/hardware-components"
+	packet-hardware inventory --verbose --tinkerbell "${tinkerbell}/hardware-components"
 	;;
 esac
 


### PR DESCRIPTION
## Description

In a previous merge, the `inventory` argument was missed from the new `packet-hardware` command call.