### PR TITLE
include PACKET_BOOTDEV_MAC env during preinstall

### DIFF
--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -67,9 +67,16 @@ class Handler:
         log = log.bind(hardware_id=hardware_id, instance_id=instance_id)
         start = datetime.now()
 
+        env = {"PACKET_BOOTDEV_MAC": os.getenv("PACKET_BOOTDEV_MAC", "")}
         log.info("running docker")
         self.run_osie(
-            hardware_id, instance_id, tinkerbell, statedir, "flavor-runner.sh", args
+            hardware_id,
+            instance_id,
+            tinkerbell,
+            statedir,
+            "flavor-runner.sh",
+            args,
+            env,
         )
         log.info("finished", elapsed=str(datetime.now() - start))
 

--- a/osie-runner/test_handlers.py
+++ b/osie-runner/test_handlers.py
@@ -99,6 +99,7 @@ def test_preinstalling(handler):
         handler.host_state_dir,
         "flavor-runner.sh",
         ("-M", "/statedir/metadata"),
+        {"PACKET_BOOTDEV_MAC": ""},
     )
 
     handler.handle_preinstalling(cacher_preinstalling)


### PR DESCRIPTION
`PACKET_BOOTDEV_MAC` is an environment variable used during preinstall
in case a re-dhcp is needed in order to find the proper interface to
attempt those re-dhcp requests from.