### PR TITLE
Log OSIE failures to tinkerbell using a bash trap function

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -27,6 +27,24 @@ function rainbow() {
 	echo -e "$NC:NC"
 }
 
+function print_stack_trace() {
+	echo -e "Bash Stacktrace:\n"
+
+	for ((i = 0; i < ${#FUNCNAME[@]}; i++)); do
+		if [[ "${FUNCNAME[i]}" == print_stack_trace ]]; then
+			# skip displaying this function in the stack trace
+			continue
+		fi
+		if ((i > 0)); then
+			line="${BASH_LINENO[$((i - 1))]}"
+		else
+			line="${LINENO}"
+		fi
+		printf ' at %s (file "%s" line %d)\n' "${FUNCNAME[i]}" \
+			"${BASH_SOURCE[i]}" "${line}"
+	done
+}
+
 # syntax: phone_home 1.2.3.4 '{"this": "data"}'
 function phone_home() {
 	local tink_host=$1

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -62,6 +62,7 @@ function autofail() {
 	# shellcheck disable=SC2181
 	(($? == 0)) && exit
 
+	print_stack_trace
 	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"${autofail_reason}"'"}'
 }
 trap autofail EXIT


### PR DESCRIPTION
Similar to what we do in osie-runner, this sets up a bash trap
function named autofail() which logs to tinkerbell an error message
based on the `autofail_reason` variable, which we update in various
sections of the script to reflect which code section the failure
occurred.