### PR TITLE
allow specific syslog server

### DIFF
--- a/apps/osie-installer.sh
+++ b/apps/osie-installer.sh
@@ -71,6 +71,7 @@ packet_base_url=$(sed -nr 's|.*\bpacket_base_url=(\S+).*|\1|p' /proc/cmdline)
 pwhash=$(sed -nr 's|.*\bpwhash=(\S+).*|\1|p' /proc/cmdline)
 kslug=$(sed -nr 's|.*\bslug=(\S+).*|\1|p' /proc/cmdline)
 eclypsium_token=$(sed -nr 's|.*\beclypsium_token=(\S+).*|\1|p' /proc/cmdline)
+syslog_host=$(sed -nr 's|.*\bsyslog_host=(\S+).*|\1|p' /proc/cmdline)
 
 case $kslug in
 *deprovision*) state=deprovision ;;
@@ -180,11 +181,13 @@ other_consoles=$(
 		head -n-1
 )
 
+[ -z "$syslog_host" ] && syslog_host="$tinkerbell"
+
 reason='docker exited with an error'
 docker run --privileged -ti \
 	-h "${hardware_id}" \
 	-e "container_uuid=$id" \
-	-e "RLOGHOST=$tinkerbell" \
+	-e "RLOGHOST=$syslog_host" \
 	-e "ECLYPSIUM_TOKEN=${eclypsium_token:-}" \
 	-v /dev:/dev \
 	-v /dev/console:/dev/console \

--- a/apps/runner.sh
+++ b/apps/runner.sh
@@ -63,6 +63,7 @@ ______          _        _                _
 EOF
 
 facility=$(sed -nr 's|.*\bfacility=(\S+).*|\1|p' /proc/cmdline)
+syslog_host=$(sed -nr 's|.*\bsyslog_host=(\S+).*|\1|p' /proc/cmdline)
 
 ensure_time
 
@@ -82,6 +83,7 @@ packet_base_url=$(sed -nr 's|.*\bpacket_base_url=(\S+).*|\1|p' /proc/cmdline)
 packet_bootdev_mac=$(sed -nr 's|.*\bpacket_bootdev_mac=(\S+).*|\1|p' /proc/cmdline)
 facility=$(jq -r .facility "$metadata")
 phone_home_url=$(jq -r .phone_home_url "$metadata")
+tinkerbell=$(jq -r .phone_home_url "$metadata" | sed -e 's|^http://||' -e 's|/.*||')
 
 trap fail EXIT
 
@@ -120,9 +122,12 @@ other_consoles=$(
 		head -n-1
 )
 
+[ -z "$syslog_host" ] && syslog_host="$tinkerbell"
+
 while true; do
 	reason='docker exited with an error'
 	docker run -ti \
+		-e "RLOGHOST=$syslog_host" \
 		-e "PACKET_BASE_URL=$packet_base_url" \
 		-e "PACKET_BOOTDEV_MAC=${packet_bootdev_mac:-}" \
 		-e "STATEDIR_HOST=$statedir" \

--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -23,7 +23,9 @@ class Handler:
     ):
         cmd = ("docker", "run", "--rm", "--privileged", "-ti", "-h", hardware_id)
 
-        envs = (f"container_uuid={instance_id}", f"RLOGHOST={tinkerbell.hostname}")
+        rloghost = os.getenv("RLOGHOST", tinkerbell.hostname)
+
+        envs = (f"container_uuid={instance_id}", f"RLOGHOST={rloghost}")
         envs += tuple(itertools.starmap("=".join, zip(env.items())))
         # prepends a '-e' before each env
         cmd += tuple(itertools.chain(*zip(("-e",) * len(envs), envs)))


### PR DESCRIPTION
Currently the syslog server is pointed to the same tinkerbell host
as used for multiple other requests. This change allows the syslog
server to be defined separately but will fallback to the tinkerbell
host if one is not provided.

To define this simply add `syslog_host=my.host` to the kernel parameters
when booting osie.