### PR TITLE
Eng 8520 nsx admin user

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,7 @@ clone:
   git:
     image: quay.io/packet/drone-git
     tags: true
+    pull: true
 
 pipeline:
   build_osie_test_env_image:

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -616,13 +616,13 @@ function bash_aa_to_json() {
 	echo -n "${_json}"
 }
 
-function set_root_pw() {
+function set_pw() {
 	# TODO
 	# FIXME: make sure we don't log pwhash whenever osie logging to kibana happens
 	# TODO
-	echo -e "${GREEN}#### Setting rootpw${NC}"
-	sed -i "s|^root:[^:]*|root:$1|" "$2"
-	grep '^root' "$2"
+	echo -e "${GREEN}#### Setting password${NC}"
+	sed -i "s|^$1:[^:]*|$1:$2|" "$3"
+	grep "^$1" "$3"
 }
 
 function vmlinuz_version() {

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -573,7 +573,11 @@ fi
 
 autofail_reason='error setting root password'
 echo -e "${GREEN}#### Setting password${NC}"
-set_pw "root" "$pwhash" $target/etc/shadow
+pwuser="root"
+if [[ ${OS} =~ vmware_nsx_3_0_0 ]]; then
+	pwuser="admin"
+fi
+set_pw "$pwuser" "$pwhash" $target/etc/shadow
 
 # ensure unique dbus/systemd machine-id, will be based off of container_uuid aka instance_id
 autofail_reason='error setting machine-id'

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -572,8 +572,8 @@ if [[ $pwhash == "preinstall" ]]; then
 fi
 
 autofail_reason='error setting root password'
-echo -e "${GREEN}#### Setting root password${NC}"
-set_root_pw "$pwhash" $target/etc/shadow
+echo -e "${GREEN}#### Setting password${NC}"
+set_pw "root" "$pwhash" $target/etc/shadow
 
 # ensure unique dbus/systemd machine-id, will be based off of container_uuid aka instance_id
 autofail_reason='error setting machine-id'

--- a/docker/scripts/vosie.sh
+++ b/docker/scripts/vosie.sh
@@ -205,7 +205,7 @@ done
 sed -i "s/PACKET_ROOT_UUID/$rootuuid/g" $target/boot/grub/grub.cfg
 sed -i "s/PACKET_BOOT_UUID/$bootuuid/g" $target/boot/grub/grub.cfg
 
-set_root_pw "$pwhash" $target/etc/shadow
+set_pw "root" "$pwhash" $target/etc/shadow
 
 echo -e "${GREEN}#### Setting up network config${NC}"
 # tinkerbell provides DNS servers to OSIE via dhcp and udhcpc writes out


### PR DESCRIPTION
## Description

This makes the set password function more generic in order to support alternative superuser names (admin) in the case of VMware NSX.

## Why is this needed

This is required in order to keep the default superuser name for VMware NSX

Fixes: #

## How Has This Been Tested?
Testing custom OSIE release for provisions of ubuntu, virtuozo (vosie) and NSX.


## How are existing users impacted? What migration steps/scripts do we need?

None.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
