### PR TITLE
Gather and report CPLD version and more

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ pipeline:
 
   shellcheck:
     group: ci1
-    image: koalaman/shellcheck-alpine
+    image: koalaman/shellcheck-alpine:stable
     commands:
       - shellcheck apps/*.sh ci/*.sh
       - cd docker/scripts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,6 +118,24 @@ RUN cd /tmp/osie && \
     install -m 755 /tmp/osie/ipmicfg /usr/bin/ipmicfg && \
     rm -rf /tmp/osie
 
+# RACADM
+COPY dchipm.ini /tmp/osie/
+RUN cd /tmp/osie && \
+    if [ $(uname -m) != 'aarch64' ]; then \
+      apt-get update && apt-get install -y alien && \
+      rpm --import http://linux.dell.com/repo/pgp_pubkeys/0x1285491434D8786F.asc && \
+      wget \
+        https://dl.dell.com/FOLDER05920767M/1/DellEMC-iDRACTools-Web-LX-9.4.0-3732_A00.tar.gz \
+        http://linux.dell.com/repo/community/openmanage/940/bionic/pool/main/s/srvadmin-omilcore/srvadmin-omilcore_9.4.0_amd64.deb && \
+      tar -xvf DellEMC-iDRACTools-Web-LX-9.4.0-3732_A00.tar.gz && \
+      alien -i iDRACTools/racadm/RHEL8/x86_64/*.rpm && \
+      dpkg -i *.deb && \
+      apt-get purge -y alien && \
+      apt-get autoremove -y && \
+      cp dchipm.ini /opt/dell/srvadmin/etc/srvadmin-hapi/ini/ ; \
+    fi && \
+    rm -rf /tmp/osie
+
 # URL=http://www.mellanox.com/downloads/firmware/mlxup
 # VERSION=4.6.0
 COPY lfs/mlxup-* /tmp/osie/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -112,6 +112,12 @@ RUN cd /tmp/osie && \
     cd && \
     rm -r /tmp/osie
 
+# IPMICFG
+COPY lfs/ipmicfg /tmp/osie/
+RUN cd /tmp/osie && \
+    install -m 755 /tmp/osie/ipmicfg /usr/bin/ipmicfg && \
+    rm -rf /tmp/osie
+
 # URL=http://www.mellanox.com/downloads/firmware/mlxup
 # VERSION=4.6.0
 COPY lfs/mlxup-* /tmp/osie/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update -y && \
     apt-get -qy clean && \
     rm -rf /var/lib/apt/lists/* /tmp/osie/
 
-ARG PACKET_HARDWARE_COMMIT=4702a57d31a86c12ae6b016a88edcc15ee64a42d
+ARG PACKET_HARDWARE_COMMIT=b4e85b9fe707573bcc54954c4f85e620f5c8753f
 ARG PACKET_NETWORKING_COMMIT=dd13b2a94daace22ecd97f053b878dbfcf20cb80
 
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 && \

--- a/docker/dchipm.ini
+++ b/docker/dchipm.ini
@@ -1,0 +1,9 @@
+hapi.openipmi.driverstarted=yes
+hapi.openipmi.issupportedversion=yes
+hapi.openipmi.driverpattern=ipmi_
+hapi.openipmi.basedriverprefix=ipmi_si
+hapi.openipmi.ispoweroffcapable=yes
+hapi.openipmi.poweroffmodule=ipmi_poweroff
+hapi.openipmi.powercyclemodule=ipmi_poweroff
+hapi.openipmi.powercyclecommand=poweroff_powercycle=1
+hapi.allow.user.mode=no

--- a/docker/lfs/ipmicfg
+++ b/docker/lfs/ipmicfg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dc136b40ff61c6969b2491cb7d4d0e31ee12e5b0e5059be147c380f18c1cf68
+size 826611


### PR DESCRIPTION
## Description

Lets add racadm and ipmicfg and update packet-hardware.

## Why is this needed

Need these so we can gather the CPLD version and more from Dell and Supermicro equipment

## How Has This Been Tested?
Tested from within OSIE container and on several Ubuntu 16 machines
Corresponds with packethost/packet-hardware/pull/1


## How are existing users impacted? What migration steps/scripts do we need?
No break. Only fix. 🤞 

