### PR TITLE
Changes for osie to have centralized logging in tinkerbell

### DIFF
--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -11,6 +11,10 @@ registry_password=$(sed -nr 's|.*\bregistry_password=(\S+).*|\1|p' /proc/cmdline
 tinkerbell=$(sed -nr 's|.*\btinkerbell=(\S+).*|\1|p' /proc/cmdline)
 worker_id=$(sed -nr 's|.*\bworker_id=(\S+).*|\1|p' /proc/cmdline)
 id=$(curl --connect-timeout 60 "$tinkerbell:50061/metadata" | jq -r .id)
+log_driver=$(sed -nr 's|.*\blog_driver=(\S+).*|\1|p' /proc/cmdline)
+log_tag=$(sed -nr 's|.*\blog_tag=(\S+).*|\1|p' /proc/cmdline)
+log_server_address=$(sed -nr 's|.*\blog_server_address=(\S+).*|\1|p' /proc/cmdline)
+log_server_address_type=$(sed -nr 's|.*\blog_server_address_type=(\S+).*|\1|p' /proc/cmdline)
 
 # Create workflow motd
 cat <<'EOF'
@@ -71,8 +75,15 @@ docker run --privileged -t --name "tink-worker" \
 	-e "TINKERBELL_CERT_URL=$grpc_cert_url" \
 	-e "REGISTRY_USERNAME=$registry_username" \
 	-e "REGISTRY_PASSWORD=$registry_password" \
+	-e "LOG_DRIVER=$log_driver" \
+	-e "LOG_SERVER_ADDRESS_TYPE=$log_server_address_type" \
+	-e "LOG_SERVER_ADDRESS=$log_server_address" \
+	-e "LOG_TAG=$log_tag" \
 	-v /worker:/worker \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-t \
 	--net host \
+	--log-driver "$log_driver" \
+	--log-opt "$log_server_address_type"="$log_server_address" \
+	--log-opt tag="$log_tag" \
 	"$docker_registry/tink-worker:latest"

--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -14,7 +14,6 @@ id=$(curl --connect-timeout 60 "$tinkerbell:50061/metadata" | jq -r .id)
 log_driver=$(sed -nr 's|.*\blog_driver=(\S+).*|\1|p' /proc/cmdline)
 log_opt_tag=$(sed -nr 's|.*\blog_opt_tag=(\S+).*|\1|p' /proc/cmdline)
 log_opt_server_address=$(sed -nr 's|.*\blog_opt_server_address=(\S+).*|\1|p' /proc/cmdline)
-log_opt_server_address_type=$(sed -nr 's|.*\blog_opt_server_address_type=(\S+).*|\1|p' /proc/cmdline)
 
 # Create workflow motd
 cat <<'EOF'
@@ -76,7 +75,6 @@ docker run --privileged -t --name "tink-worker" \
 	-e "REGISTRY_USERNAME=$registry_username" \
 	-e "REGISTRY_PASSWORD=$registry_password" \
 	-e "LOG_DRIVER=$log_driver" \
-	-e "LOG_OPT_SERVER_ADDRESS_TYPE=$log_opt_server_address_type" \
 	-e "LOG_OPT_SERVER_ADDRESS=$log_opt_server_address" \
 	-e "LOG_OPT_TAG=$log_opt_tag" \
 	-v /worker:/worker \
@@ -84,6 +82,6 @@ docker run --privileged -t --name "tink-worker" \
 	-t \
 	--net host \
 	--log-driver "$log_driver" \
-	--log-opt "$log_opt_server_address_type"="$log_opt_server_address" \
-	--log-opt tag="$log_opt_tag" \
+	--log-opt "$log_driver-address=$log_opt_server_address" \
+	--log-opt "tag=$log_opt_tag" \
 	"$docker_registry/tink-worker:latest"

--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -12,9 +12,9 @@ tinkerbell=$(sed -nr 's|.*\btinkerbell=(\S+).*|\1|p' /proc/cmdline)
 worker_id=$(sed -nr 's|.*\bworker_id=(\S+).*|\1|p' /proc/cmdline)
 id=$(curl --connect-timeout 60 "$tinkerbell:50061/metadata" | jq -r .id)
 log_driver=$(sed -nr 's|.*\blog_driver=(\S+).*|\1|p' /proc/cmdline)
-log_tag=$(sed -nr 's|.*\blog_tag=(\S+).*|\1|p' /proc/cmdline)
-log_server_address=$(sed -nr 's|.*\blog_server_address=(\S+).*|\1|p' /proc/cmdline)
-log_server_address_type=$(sed -nr 's|.*\blog_server_address_type=(\S+).*|\1|p' /proc/cmdline)
+log_opt_tag=$(sed -nr 's|.*\blog_opt_tag=(\S+).*|\1|p' /proc/cmdline)
+log_opt_server_address=$(sed -nr 's|.*\blog_opt_server_address=(\S+).*|\1|p' /proc/cmdline)
+log_opt_server_address_type=$(sed -nr 's|.*\blog_opt_server_address_type=(\S+).*|\1|p' /proc/cmdline)
 
 # Create workflow motd
 cat <<'EOF'
@@ -76,14 +76,14 @@ docker run --privileged -t --name "tink-worker" \
 	-e "REGISTRY_USERNAME=$registry_username" \
 	-e "REGISTRY_PASSWORD=$registry_password" \
 	-e "LOG_DRIVER=$log_driver" \
-	-e "LOG_SERVER_ADDRESS_TYPE=$log_server_address_type" \
-	-e "LOG_SERVER_ADDRESS=$log_server_address" \
-	-e "LOG_TAG=$log_tag" \
+	-e "LOG_OPT_SERVER_ADDRESS_TYPE=$log_opt_server_address_type" \
+	-e "LOG_OPT_SERVER_ADDRESS=$log_opt_server_address" \
+	-e "LOG_OPT_TAG=$log_opt_tag" \
 	-v /worker:/worker \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-t \
 	--net host \
 	--log-driver "$log_driver" \
-	--log-opt "$log_server_address_type"="$log_server_address" \
-	--log-opt tag="$log_tag" \
+	--log-opt "$log_opt_server_address_type"="$log_opt_server_address" \
+	--log-opt tag="$log_opt_tag" \
 	"$docker_registry/tink-worker:latest"

--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -68,7 +68,7 @@ rm -f /sbin/mdev
 mkdir /worker
 
 logging_configuration=""
-if [ "$centralized_logging" = "True" ]; then
+if [ "$centralized_logging" = "enable" ]; then
 	logging_configuration="--log-driver $log_driver \
   	                     --log-opt $log_driver-address=$log_opt_server_address \
   	                     --log-opt tag=$log_opt_tag "

--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -68,8 +68,8 @@ rm -f /sbin/mdev
 mkdir /worker
 
 logging_configuration=""
-if [ $centralized_logging = "True" ]; then
-  logging_configuration="--log-driver $log_driver \
+if [ "$centralized_logging" = "True" ]; then
+	logging_configuration="--log-driver $log_driver \
   	                     --log-opt $log_driver-address=$log_opt_server_address \
   	                     --log-opt tag=$log_opt_tag "
 fi
@@ -82,6 +82,7 @@ docker run --privileged -t --name "tink-worker" \
 	-e "TINKERBELL_CERT_URL=$grpc_cert_url" \
 	-e "REGISTRY_USERNAME=$registry_username" \
 	-e "REGISTRY_PASSWORD=$registry_password" \
+	-e "CENTRALIZED_LOGGING=$centralized_logging" \
 	-e "LOG_DRIVER=$log_driver" \
 	-e "LOG_OPT_SERVER_ADDRESS=$log_opt_server_address" \
 	-e "LOG_OPT_TAG=$log_opt_tag" \
@@ -89,5 +90,5 @@ docker run --privileged -t --name "tink-worker" \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-t \
 	--net host \
-	$logging_configuration \
+	"$logging_configuration" \
 	"$docker_registry/tink-worker:latest"


### PR DESCRIPTION
Signed-off-by: cbkhare <Chitrabasukhare89@gmail.com>

## Description

Changes to add centralized logging for the Tinkerbell. 

## Why is this needed

- We need a log aggregator for Tinkerbell which can collect log from tink services and tink worker containers. 
- boots PR: https://github.com/tinkerbell/boots/pull/73
- Tink PR: https://github.com/tinkerbell/tink/pull/267
- RFD: https://github.com/tinkerbell/proposals/pull/7

Fixes: #

## How Has This Been Tested?
- [x] Tested with basic hello-world example.
- [x] Verified the testing of logrotation.
- [x] Added below test results. 

**log_aggregation**
```
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/
total 20
drwxr-xr-x 2 syslog syslog 4096 Sep  8 12:59 provisioner
-rw-r----- 1 syslog adm    9521 Sep  8 13:04 daemon.log
drwxr-xr-x 2 syslog syslog 4096 Sep  8 13:17 192.168.1.5
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/192.168.1.5/
total 12
-rw-r----- 1 syslog adm 2985 Sep  8 13:17 hello_world_0e65404d-5abe-4746-b6a9-bba9be867884.log
-rw-r----- 1 syslog adm 4789 Sep  8 13:17 tink-worker.log
```

**logrotation**:
```
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/provisioner/
total 36
-rw-r----- 1 syslog adm  513 Sep  8 13:04 deploy_db_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 4099 Sep  8 13:17 deploy_boots_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm  577 Sep  8 13:17 deploy_nginx_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm  400 Sep  8 13:17 deploy_hegel_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 1450 Sep  8 13:17 deploy_tink-server_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 6155 Sep  8 13:37 deploy_registry_1.log-20200908131599572256.gz
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_boots_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_db_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_hegel_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_nginx_1.log
-rw-r----- 1 syslog adm    0 Sep  8 13:37 deploy_tink-server_1.log
-rw-r----- 1 syslog adm  147 Sep  8 13:37 deploy_registry_1.log
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/192.168.1.5/
total 8
-rw-r----- 1 syslog adm 571 Sep  8 13:17 hello_world_0e65404d-5abe-4746-b6a9-bba9be867884.log-20200908131599572256.gz
-rw-r----- 1 syslog adm 918 Sep  8 13:17 tink-worker.log-20200908131599572256.gz
-rw-r----- 1 syslog adm   0 Sep  8 13:37 hello_world_0e65404d-5abe-4746-b6a9-bba9be867884.log
-rw-r----- 1 syslog adm   0 Sep  8 13:37 tink-worker.log
vagrant@provisioner:/vagrant/deploy$ ls -lrt   /var/log/dockerlfs/
total 12
-rw-r----- 1 syslog adm    1642 Sep  8 13:04 daemon.log-20200908131599572256.gz
-rw-r----- 1 syslog adm       0 Sep  8 13:37 daemon.log
drwxr-xr-x 2 syslog syslog 4096 Sep  8 13:37 192.168.1.5
drwxr-xr-x 2 syslog syslog 4096 Sep  8 13:37 provisioner

``` 

## How are existing users impacted? What migration steps/scripts do we need?

- Log location has been updated. Documentation will need an update.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
