### PR TITLE
Add an .editorconfig file for this repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.sh]
+indent_style = tab
+
+[*.py]
+indent_style = space

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,3 @@
-# vim: set expandtab shiftwidth=4 softtabstop=4:
 FROM alpine:3.12
 
 RUN apk add --no-cache --no-progress --update --upgrade \


### PR DESCRIPTION
Specifies tab indent style for bash scripts and space indent style for python scripts.
