### PR TITLE
DO NOT MERGE: Do not automatically fail provisions when autofail() is triggered

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -63,7 +63,7 @@ function autofail() {
 	(($? == 0)) && exit
 
 	print_stack_trace
-	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"${autofail_reason}"'"}'
+	puttink "${tinkerbell}" phone-home '{"type":"autofail", "reason":"'"${autofail_reason}"'"}'
 }
 trap autofail EXIT
 


### PR DESCRIPTION
We seem to be having instances that are failing with an autofail
message, but the provision continues and the system appears to complete
the provisioning process anyway. Until we have a clearer idea of how
this is happening, do not mark provisions as failed.