### PR TITLE
Dump cacher metadata at the start of handle_provisioning()

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -28,6 +28,8 @@ function rainbow() {
 }
 
 function print_stack_trace() {
+	set +x
+
 	echo -e "Bash Stacktrace:\n"
 
 	for ((i = 0; i < ${#FUNCNAME[@]}; i++)); do

--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -114,6 +114,9 @@ class Handler:
         statedir = self.host_state_dir
         tinkerbell = self.tinkerbell
 
+        print("DEBUG: cacher metadata:")
+        print(json.dumps(j, indent=2))
+
         hardware_id = j["id"]
         instance = j.get("instance")
         if not instance:


### PR DESCRIPTION
This enables some additional debug information we can use to track down some issues around when the network_ready event is received.