### PR TITLE
Dump cacher in run.py

### DIFF
--- a/osie-runner/handlers.py
+++ b/osie-runner/handlers.py
@@ -114,9 +114,6 @@ class Handler:
         statedir = self.host_state_dir
         tinkerbell = self.tinkerbell
 
-        print("DEBUG: cacher metadata:")
-        print(json.dumps(j, indent=2))
-
         hardware_id = j["id"]
         instance = j.get("instance")
         if not instance:

--- a/osie-runner/run.py
+++ b/osie-runner/run.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import copy
 import itertools
 import json
 import logging
@@ -76,6 +77,15 @@ def connect_hegel(facility):
             pass
 
 
+def sanitize_cacher_data(j):
+    j = copy.deepcopy(j)
+    try:
+        j["instance"]["userdata"] = "~~ OMITTED ~~"
+    except Exception as e:
+        pass
+    return j
+
+
 with open("/proc/cmdline", "r") as cmdline:
     cmdline_content = cmdline.read()
     tinkerbell = parse.urlparse(util.value_from_kopt(cmdline_content, "tinkerbell"))
@@ -103,7 +113,7 @@ while True:
     state = j["state"]
     i = j.get("instance", {"state": ""})
     log.info("context updated", state=state, instance_state=i.get("state", ""))
-    print(json.dumps(j, indent=2))
+    print(json.dumps(sanitize_cacher_data(j), indent=2))
 
     handler = handlers.handler(state)
     if handler:

--- a/osie-runner/run.py
+++ b/osie-runner/run.py
@@ -103,6 +103,7 @@ while True:
     state = j["state"]
     i = j.get("instance", {"state": ""})
     log.info("context updated", state=state, instance_state=i.get("state", ""))
+    print(json.dumps(j, indent=2))
 
     handler = handlers.handler(state)
     if handler:


### PR DESCRIPTION
## Description

Dump cacher data in osie-runner's run.py instead of handler.py.
This is done regardless of the new state which helps in debugging.

## Why is this needed

Provision failures in Packet Production and we need better info to fully debug.


## How Has This Been Tested?

It has not been tested.

## How are existing users impacted? What migration steps/scripts do we need?

No expected impact.