### PR TITLE
Print error summary to console before exiting

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -37,26 +37,6 @@ function print_error_summary() {
 	echo -e "********************************************\n"
 }
 
-function print_stack_trace() {
-	set +x
-
-	echo -e "Bash Stacktrace:\n"
-
-	for ((i = 0; i < ${#FUNCNAME[@]}; i++)); do
-		if [[ "${FUNCNAME[i]}" == print_stack_trace ]]; then
-			# skip displaying this function in the stack trace
-			continue
-		fi
-		if ((i > 0)); then
-			line="${BASH_LINENO[$((i - 1))]}"
-		else
-			line="${LINENO}"
-		fi
-		printf ' at %s (file "%s" line %d)\n' "${FUNCNAME[i]}" \
-			"${BASH_SOURCE[i]}" "${line}"
-	done
-}
-
 # syntax: phone_home 1.2.3.4 '{"this": "data"}'
 function phone_home() {
 	local tink_host=$1

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -27,6 +27,16 @@ function rainbow() {
 	echo -e "$NC:NC"
 }
 
+# user-friendly display of OSIE errors
+function print_error_summary() {
+	set +x
+	local reason=$1
+
+	echo -e "\n************ OSIE ERROR SUMMARY ************"
+	echo -e "Reason: ${reason}"
+	echo -e "********************************************\n"
+}
+
 function print_stack_trace() {
 	set +x
 

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -64,6 +64,7 @@ function autofail() {
 
 	print_stack_trace
 	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"${autofail_reason}"'"}'
+	print_error_summary "${autofail_reason}"
 }
 trap autofail EXIT
 

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -62,7 +62,6 @@ function autofail() {
 	# shellcheck disable=SC2181
 	(($? == 0)) && exit
 
-	print_stack_trace
 	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"${autofail_reason}"'"}'
 	print_error_summary "${autofail_reason}"
 }


### PR DESCRIPTION
This is intended to display the autofail_reason cleanly and prominently as the final thing before OSIE exits on failure. Right now there's not much to this function but I'm envisioning future improvements that will help to categorize failures (hw vs. site controller, etc) and offer advice on how to troubleshoot them.