### PR TITLE
dockerfile: update packet-hardware to v1.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update -y && \
     apt-get -qy clean && \
     rm -rf /var/lib/apt/lists/* /tmp/osie/
 
-ARG PACKET_HARDWARE_COMMIT=b4e85b9fe707573bcc54954c4f85e620f5c8753f
+ARG PACKET_HARDWARE_COMMIT=413cdf9392a7c962081403d942666152afd1d843
 ARG PACKET_NETWORKING_COMMIT=dd13b2a94daace22ecd97f053b878dbfcf20cb80
 
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 && \


### PR DESCRIPTION
This brings in some additional fixes for component information 
collection on Supermicro BMCs.

Signed-off-by: Dustin Miller <dustin@packet.com>

## Description

Lets report a better BMC model for Supermicro boards that report back things like the vague 'Super Server'

## Why is this needed

Firmware pinning needs a more granular name than 'Super Server' and we'll do some normalizing on odd results too.

## How Has This Been Tested?
Tested packet-hardware changes inside a running OSIE container

## How are existing users impacted? What migration steps/scripts do we need?
No break, only fix 🤞 
