### PR TITLE
Fix the deploy-osie command example

### DIFF
--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -92,8 +92,8 @@ deploy: package
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/$v.tar.gz"
 	$(Q) mc cp build/$v.tar.gz s3/${s3Bucket}/osie-uploads/$v.tar.gz
 	$(Q) if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz s3/tinkerbell-oss/osie-uploads/latest.tar.gz; fi
-	$(Q) echo "deploy this build with the following command:"
-	$(Q) echo -n "./scripts/deploy osie update $v -m \"$$"
+	$(Q) echo "deploy this build from the deploy-osie repo with the following command:"
+	$(Q) echo -n "./deploy update $v -m \"$$"
 	$(Q) echo -n "(sed -n '/^## \[/,$$ {/\S/!q; p}' CHANGELOG.md)\" "
 	$(Q) echo -n "$$(sed 's|.*= ||' build/$v.tar.gz.sha512sum)"
 	$(Q) echo


### PR DESCRIPTION
We've updated the syntax of the osie deployment command, this updates the example to reflect these changes.