### PR TITLE
Track OSIE version information

### DIFF
--- a/apps/runner.sh
+++ b/apps/runner.sh
@@ -60,6 +60,7 @@ ______          _        _                _
 \_|  \__,_|\___|_|\_\___|\__(_)_| |_|\___|\__|
 ===============================================
 ##          Task Runner Environment          ##
+## OSIE Version: ${OSIE_VERSION} (${OSIE_BRANCH})
 EOF
 
 facility=$(sed -nr 's|.*\bfacility=(\S+).*|\1|p' /proc/cmdline)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,14 @@ LABEL Description="Ubuntu baremetal installation image" Vendor="Packet.net" Vers
 VOLUME /statedir
 ENTRYPOINT ["/entrypoint.sh"]
 
+ARG GITVERSION
+ARG GITBRANCH
+ARG DRONEBUILD
+
+ENV OSIE_VERSION ${GITVERSION}
+ENV OSIE_BRANCH ${GITBRANCH}
+ENV DRONE_BUILD ${DRONEBUILD}
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -34,6 +34,8 @@ function print_error_summary() {
 
 	echo -e "\n************ OSIE ERROR SUMMARY ************"
 	echo -e "Reason: ${reason}"
+	echo -e "OSIE Version: ${OSIE_VERSION} (${OSIE_BRANCH})"
+	echo -e "Drone Build: ${DRONE_BUILD}"
 	echo -e "********************************************\n"
 }
 

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -80,6 +80,8 @@ mirror=${mirror:-http://mirror.$facility.packet.net}
 ## Tell the API we're connected to the magic install system
 phone_home "${tinkerbell}" '{"type":"provisioning.104"}'
 
+echo -e "${GREEN}### OSIE Version ${OSIE_VERSION} (${OSIE_BRANCH})${NC}"
+
 ## Pre-prov check
 echo -e "${GREEN}#### Starting pre-provisioning checks...${NC}"
 

--- a/installer/alpine/build.sh
+++ b/installer/alpine/build.sh
@@ -34,6 +34,7 @@ build_initramfs() {
 	kver=$(basename /lib/modules/*)
 	mkinitfs -l "$kver"
 	mkinitfs -o /assets/initramfs "$kver"
+	chmod a+r /assets/initramfs
 }
 
 build_modloop() {

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -4,6 +4,14 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python3", "run.py"]
 VOLUME /statedir
 
+ARG GITVERSION
+ARG GITBRANCH
+ARG DRONEBUILD
+
+ENV OSIE_VERSION ${GITVERSION}
+ENV OSIE_BRANCH ${GITBRANCH}
+ENV DRONE_BUILD ${DRONEBUILD}
+
 WORKDIR /tmp
 RUN apk add --update --upgrade --no-cache bash docker jq libstdc++ python3
 COPY requirements.txt .

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -8,6 +8,10 @@ x86s := x86_64
 arms := 2a2 aarch64 amp hua qcom tx2
 parches := $(sort $(arms) $(x86s))
 
+gitversion=$(shell git rev-parse HEAD)
+gitbranch=$(shell git symbolic-ref --short HEAD)
+dronebuild=$(shell echo $${DRONE_BUILD:-none})
+
 target_checksum = $(word 4,$(subst -, ,$(1)))
 build_path = $(word 3,$(1))/$(word 2,$(1))-vanilla-$(word 1,$(1))
 target_to_path = $(call build_path,$(subst -, ,$(1)))
@@ -206,7 +210,7 @@ build/osie-x86_64.tar.gz:  SED=
 build/osie-%.tar.gz: docker/Dockerfile ${osiesrcs}
 	$(E) "DOCKER   $@"
 	$(Q) sed '${SED}' $< > $<.$*
-	$(Q) docker build -t osie:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
+	$(Q) docker build --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
 	$(Q) docker save osie:$* > $@.tmp
 	$(Q) mv $@.tmp $@
 
@@ -218,7 +222,7 @@ build/osie-runner-x86_64.tar.gz:  SED=
 build/osie-runner-%.tar.gz: osie-runner/Dockerfile $(shell git ls-files osie-runner)
 	$(E) "DOCKER   $@"
 	$(Q) sed '${SED}' $< > $<.$*
-	$(Q) docker build -t osie-runner:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
+	$(Q) docker build --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie-runner:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
 	$(Q) docker save osie-runner:$* > $@.tmp
 	$(Q) mv $@.tmp $@
 


### PR DESCRIPTION
Normally I'd create a file called VERSION that would get packaged up and could be read from, but since we're generating multiple containers, ensuring access to this file gets a bit complicated. So I thought it would be easier to template some variables in specific OSIE scripts that could be substituted at build time.

Consider this an RFC pull request and if we can get consensus on the technical approach for this, there are several more areas where we can make use of this version information - e.g, sending it to hegel on initial connection.