### PR TITLE
Fix file perms when generating initramfs

### DIFF
--- a/installer/alpine/build.sh
+++ b/installer/alpine/build.sh
@@ -34,6 +34,7 @@ build_initramfs() {
 	kver=$(basename /lib/modules/*)
 	mkinitfs -l "$kver"
 	mkinitfs -o /assets/initramfs "$kver"
+	chmod a+r /assets/initramfs
 }
 
 build_modloop() {


### PR DESCRIPTION
On Ubuntu 18.04 and 20.04 I discovered that building OSIE locally would
result in a failure because the initramfs would get copied out of the
container as owned by root with user-only read permissions. This updates
the file permissions to ensure the file can be read by the build user.