### PR TITLE
is_reachable() - prevent exit errors when ping check fails

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -731,6 +731,7 @@ ip_choose_if() {
 	sleep 1
 
 	for x in /sys/class/net/eth*; do
+		[ -e "$x/carrier" ] && grep -q 1 "$x/carrier" && echo "${x##*/}" && return
 		[ -e "$x" ] && grep -q 1 "$x" && echo "${x##*/}" && return
 	done
 

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -663,6 +663,7 @@ function is_reachable() {
 
 function reacquire_dhcp() {
 	dhclient -1 "$1"
+	sleep 30
 }
 
 function ensure_reachable() {

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -657,7 +657,7 @@ function is_reachable() {
 	# Explicitly return 1 if the ping check fails in order to prevent triggering
 	# the autofail() trap
 	echo "About to run ping test"
-	ping -c1 -W1 "$host" || return 1
+	ping -c1 -W5 "$host" || return 1
 	echo "Ping test OK"
 
 	return 0

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -656,7 +656,9 @@ function is_reachable() {
 
 	# Explicitly return 1 if the ping check fails in order to prevent triggering
 	# the autofail() trap
-	ping -c1 -W1 "$host" &>/dev/null || return 1
+	echo "About to run ping test"
+	ping -c1 -W1 "$host" || return 1
+	echo "Ping test OK"
 
 	return 0
 }

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -654,7 +654,11 @@ function is_reachable() {
 		echo "host is an ipv6 address, thats not supported" >&2 && exit 1
 	fi
 
-	ping -c1 -W1 "$host" &>/dev/null
+	# Explicitly return 1 if the ping check fails in order to prevent triggering
+	# the autofail() trap
+	ping -c1 -W1 "$host" &>/dev/null || return 1
+
+	return 0
 }
 
 function reacquire_dhcp() {


### PR DESCRIPTION
This will prevent custom OS image failures for sites that block the ping
protocol.