### PR TITLE
Fix Custom OS image installs for our sites that don't support ping network checks

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -727,6 +727,7 @@ ip_choose_if() {
 	sleep 1
 
 	for x in /sys/class/net/eth*; do
+		[ -e "$x/carrier" ] && grep -q 1 "$x/carrier" && echo "${x##*/}" && return
 		[ -e "$x" ] && grep -q 1 "$x" && echo "${x##*/}" && return
 	done
 

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -686,7 +686,14 @@ function github_mirror_check() {
 	local lfs_testing_branch="remotes/origin/images-tiny"
 	if ! timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then
 		echo -e "${YELLOW}###### Timeout when cloning the lfs-testing repo${NC}"
-		return 1
+		echo -e "${YELLOW}###### Reacquiring dhcp for publicly routable ip...${NC}"
+		reacquire_dhcp "$(ip_choose_if)"
+		echo -e "${YELLOW}###### Re-checking the health of github-mirror.packet.net...${NC}"
+		if ! timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then
+			echo -e "${YELLOW}###### Timeout when cloning the lfs-testing repo${NC}"
+			return 1
+		fi
+		echo -e "${GREEN}###### Second clone attempt of lfs-testing successful${NC}"
 	fi
 	cd lfs-testing
 	if ! timeout --preserve-status $timeout git checkout -q $lfs_testing_branch; then

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -176,7 +176,7 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 
 		githost="github-mirror.packet.net"
 		# Prefer our local github-mirror, falling back to github.com
-		if ! (ensure_reachable github-mirror.packet.net && github_mirror_check); then
+		if ! github_mirror_check; then
 			echo -e "${YELLOW}###### github-mirror health check failed, falling back to using github.com${NC}"
 			githost="github.com"
 		fi
@@ -194,8 +194,6 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 		fi
 
 		gituri="${image_repo}"
-
-		ensure_reachable "$gituri"
 	fi
 	# Silence verbose notice about deatched HEAD state
 	git config --global advice.detachedHead false


### PR DESCRIPTION
This PR includes two fixes. The first is a general fix to properly detect which ethernet interface to use when re-dhcp'ing. The second eliminates ping-based checks for custom OS image installs and in our github-mirror check function.

For custom OS images, we already re-dhcp, so if there a bad git url or networking issue, allow the provision to fail during the git clone. For the github-mirror check, add a re-dhcp if the initial clone of the lfs-test repo fails.