### PR TITLE
Use pre-built binary deb packages for git

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,11 +32,10 @@ RUN apt-get update -y && \
     apt-get -qy clean && \
     rm -rf /var/lib/apt/lists/* /tmp/osie
 
-# build openssl'd git, done here so we can keep it cached as long as possible
-COPY build-git-openssl.sh /tmp/osie/
+# install custom git package built with openssl instead of gnutls
+COPY lfs/git_2.28.0-1packethost1*.deb /tmp/osie/
 RUN apt-get update -y && \
-    /tmp/osie/build-git-openssl.sh && \
-    dpkg --unpack /tmp/osie/git_*.deb && \
+    dpkg --unpack /tmp/osie/git_2.28.0-1packethost1_$(uname -m).deb && \
     apt-get install -f -y --no-install-recommends && \
     apt-get -y autoremove && \
     apt-get -y clean && \

--- a/docker/get-package-list.sh
+++ b/docker/get-package-list.sh
@@ -16,7 +16,6 @@ packages=(
 	ethtool
 	file
 	gdisk
-	git
 	grub-efi-$grub_efi_arch-bin
 	grub2-common
 	hdparm

--- a/docker/lfs/git_2.28.0-1packethost1_aarch64.deb
+++ b/docker/lfs/git_2.28.0-1packethost1_aarch64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67a36413679c4f1c235e2f20b1ae413f34abadb5e8bafc9bb58542bd1a565e53
+size 6069956

--- a/docker/lfs/git_2.28.0-1packethost1_x86_64.deb
+++ b/docker/lfs/git_2.28.0-1packethost1_x86_64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c04588de1ed193ee5e3ae87cf8d281fca8a5ed248158d5d49fc6379dd9be7ee
+size 7224422


### PR DESCRIPTION
We use custom git packages that have been built with openssl instead of
gnutls. Rather than rebuild the packages on every CI run, start using
prebuilt ones, which were built using the build-git-openssl.sh script.
That script has been updated and includes documentation in the file
header.