### PR TITLE
Testing what needs to be done to temporarily disable aarch64 builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,13 +51,13 @@ pipeline:
       - cd osie-runner
       - pytest -vv --cov=./
 
-  build_aarch64:
-    group: ci1
-    image: osie-test-env
-    commands:
-      - make V=1 T=1 build/osie-aarch64.tar.gz
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+  # build_aarch64:
+  #   group: ci1
+  #   image: osie-test-env
+  #   commands:
+  #     - make V=1 T=1 build/osie-aarch64.tar.gz
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
 
   build_x86_64:
     group: ci1
@@ -131,12 +131,12 @@ pipeline:
       - source: public_aws_secret_access_key
         target: aws_secret_access_key
 
-  test_aarch64_vm:
-    group: test
-    image: osie-test-env
-    privileged: true
-    commands:
-      - OSES=ubuntu_16_04 make V=1 T=1 UEFI=true test-aarch64
+  # test_aarch64_vm:
+  #   group: test
+  #   image: osie-test-env
+  #   privileged: true
+  #   commands:
+  #     - OSES=ubuntu_16_04 make V=1 T=1 UEFI=true test-aarch64
 
   test_x86_64_vm:
     group: test

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -3,7 +3,7 @@
 alpine_version_aarch64 := 3.4
 alpine_version_x86_64 := 3.12
 
-arches := aarch64 x86_64
+arches := x86_64
 x86s := x86_64
 arms := 2a2 aarch64 amp hua qcom tx2
 parches := $(sort $(arms) $(x86s))

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -61,16 +61,16 @@ T := null
 endif
 
 .PHONY: all deploy package package-apps package-grubs test test-aarch6 test-x86_64 v
-all: build/$v/osie-aarch64.tar.gz build/$v/osie-x86_64.tar.gz
-test: test-aarch64 test-x86_64
+all: build/$v/osie-x86_64.tar.gz
+test: test-x86_64
 v:
 	@echo $v
 
 packaged-apps := $(subst apps/,build/$v/,${apps})
 packaged-grubs := $(addprefix build/$v/,$(subst -,/,${grubs}))
 packaged-osie-runners := build/$v/osie-runner-x86_64.tar.gz
-packaged-osies := build/$v/osie-aarch64.tar.gz build/$v/osie-x86_64.tar.gz
-packaged-repos := build/$v/repo-aarch64 build/$v/repo-x86_64
+packaged-osies := build/$v/osie-x86_64.tar.gz
+packaged-repos := build/$v/repo-x86_64
 packages := ${packaged-apps} ${packaged-grubs} ${packaged-osie-runners} ${packaged-osies} ${packaged-repos}
 
 .PHONY:{% for platform in platforms.keys() %} package-{{platform}}
@@ -205,7 +205,6 @@ build/$v-rootfs-%: build/initramfs-%
 ifneq ($(CI),drone)
 build/osie-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64
 endif
-build/osie-aarch64.tar.gz: SED=/FROM/ s|.*|FROM multiarch/ubuntu-debootstrap:arm64-xenial|
 build/osie-x86_64.tar.gz:  SED=
 build/osie-%.tar.gz: docker/Dockerfile ${osiesrcs}
 	$(E) "DOCKER   $@"


### PR DESCRIPTION
Ignore me, I'm too lazy to do this locally so I'm running experiments against Drone in a PR.