### PR TITLE
Refactor autofail feature to include tracking timeouts

### DIFF
--- a/apps/runner.sh
+++ b/apps/runner.sh
@@ -126,7 +126,7 @@ other_consoles=$(
 [ -z "$syslog_host" ] && syslog_host="$tinkerbell"
 
 while true; do
-	reason='docker exited with an error'
+	reason='docker exited with an error (osie-runner)'
 	docker run -ti \
 		-e "RLOGHOST=$syslog_host" \
 		-e "PACKET_BASE_URL=$packet_base_url" \

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -30,13 +30,21 @@ function rainbow() {
 # user-friendly display of OSIE errors
 function print_error_summary() {
 	set +x
-	local reason=$1
+	local stage=$1
 
 	echo -e "\n************ OSIE ERROR SUMMARY ************"
-	echo -e "Reason: ${reason}"
+	echo -e "Reason: Error during ${stage}"
 	echo -e "OSIE Version: ${OSIE_VERSION} (${OSIE_BRANCH})"
 	echo -e "Drone Build: ${DRONE_BUILD}"
 	echo -e "********************************************\n"
+}
+
+function set_autofail_stage() {
+	local stage=$1
+
+	# shellcheck disable=SC2034
+	autofail_stage="Error during $stage"
+	echo "${stage}" >/statedir/autofail_stage
 }
 
 # syntax: phone_home 1.2.3.4 '{"this": "data"}'


### PR DESCRIPTION
The autofail() trap function in OSIE now tracks failures in two
contexts:

1. Non-zero exit codes will trigger autofail() and report an error
during the particular OSIE code stage
2. The current OSIE code stage is tracked in /statedir/autofail_stage so
it can bubble up to osie-runner, so we can reprort where hangs/timeouts
occur.

The $autofail_reason has been renamed to $autofail_stage, which is a
more accurate reflection of what it's used for.