### PR TITLE
upload latest.tar.gz.sha512sum and $v.tar.gz.sha512sum also to AWS

### DIFF
--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -106,7 +106,6 @@ deploy: package
 	$(Q) echo -n "$$(sed 's|.*= ||' build/$v.tar.gz.sha512sum)"
 	$(Q) echo
 
-
 upload-test: ${packages}
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/osie-testing/$v/"
 	$(Q) mc cp --recursive build/$v/ s3/tinkerbell-oss/osie-uploads/osie-testing/$v/ || ( \

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -96,11 +96,16 @@ deploy: package
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/$v.tar.gz"
 	$(Q) mc cp build/$v.tar.gz s3/${s3Bucket}/osie-uploads/$v.tar.gz
 	$(Q) if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz s3/tinkerbell-oss/osie-uploads/latest.tar.gz; fi
+	$(Q) echo
+	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/$v.tar.gz.sha512sum"
+	$(Q) mc cp build/$v.tar.gz.sha512sum s3/${s3Bucket}/osie-uploads/$v.tar.gz.sha512sum
+	$(Q) if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz.sha512sum s3/tinkerbell-oss/osie-uploads/latest.tar.gz.sha512sum; fi
 	$(Q) echo "deploy this build from the deploy-osie repo with the following command:"
 	$(Q) echo -n "./deploy update $v -m \"$$"
 	$(Q) echo -n "(sed -n '/^## \[/,$$ {/\S/!q; p}' CHANGELOG.md)\" "
 	$(Q) echo -n "$$(sed 's|.*= ||' build/$v.tar.gz.sha512sum)"
 	$(Q) echo
+
 
 upload-test: ${packages}
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/osie-testing/$v/"


### PR DESCRIPTION
## Description

upload latest.tar.gz.sha512sum and $v.tar.gz.sha512sum also to AWS

## Why is this needed

to make it possibly to cache and verify the osie tar locally and skip a not needed new redownload

slow or corrupt downloads 

## How Has This Been Tested?
not tested as on my system its takes a half day!

## How are existing users impacted? What migration steps/scripts do we need?
no impact for existing users.

migration steps after this RP: add the logic for the sha512sum check to 
- [ ] tink/setup.sh
- [ ] tink/generate-envrc.sh
- [ ] sandbox/setup.sh
- [ ] sandbox/generate-envrc.sh