### PR TITLE
Enable git debugging info for troubleshooting

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -692,12 +692,12 @@ function github_mirror_check() {
 	local timeout=20 # seconds
 	local lfs_testing_uri="https://github-mirror.packet.net/packethost/lfs-testing.git"
 	local lfs_testing_branch="remotes/origin/images-tiny"
-	if ! timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then
+	if ! GIT_TRACE=1 timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then
 		echo -e "${YELLOW}###### Timeout when cloning the lfs-testing repo${NC}"
 		echo -e "${YELLOW}###### Reacquiring dhcp for publicly routable ip...${NC}"
 		reacquire_dhcp "$(ip_choose_if)"
 		echo -e "${YELLOW}###### Re-checking the health of github-mirror.packet.net...${NC}"
-		if ! timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then
+		if ! GIT_TRACE=1 timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then
 			echo -e "${YELLOW}###### Timeout when cloning the lfs-testing repo${NC}"
 			return 1
 		fi

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -204,13 +204,16 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 	# Silence verbose notice about deatched HEAD state
 	git config --global advice.detachedHead false
 
+	echo -e "${YELLOW}###### GIT DEBUGGING: git config:${NC}"
+	git config -l
+
 	git -C $assetdir init
 	echo -e "${GREEN}#### Adding git remote uri: ${gituri}${NC}"
-	git -C $assetdir remote add origin "${gituri}"
+	GIT_TRACE=1 git -C $assetdir remote add origin "${gituri}"
 	echo -e "${GREEN}#### Performing a shallow git fetch for: ${image_tag}${NC}"
-	git -C $assetdir fetch --depth 1 origin "${image_tag}"
+	GIT_TRACE=1 git -C $assetdir fetch --depth 1 origin "${image_tag}"
 	echo -e "${GREEN}###### Performing a checkout of FETCH_HEAD${NC}"
-	git -C $assetdir checkout FETCH_HEAD
+	GIT_TRACE=1 git -C $assetdir checkout FETCH_HEAD
 
 	# Tell the API that the OS image has been retrieved
 	phone_home "${tinkerbell}" '{"type":"provisioning.104.50"}'


### PR DESCRIPTION
Since we can't specify a custom OSIE version when running preinstalls, this will need to be pushed to production to get the debug deets.