### PR TITLE
Eng 8427 blockstorage rebrand

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,8 +171,8 @@ RUN useradd packet -d /home/packet -m -U && \
     chown -R packet:packet /home/packet
 WORKDIR /home/packet
 
-ADD https://raw.githubusercontent.com/packethost/packet-block-storage/master/packet-block-storage-attach \
-    https://raw.githubusercontent.com/packethost/packet-block-storage/master/packet-block-storage-detach \
+ADD https://raw.githubusercontent.com/packethost/metal-block-storage/master/metal-block-storage-attach \
+    https://raw.githubusercontent.com/packethost/metal-block-storage/master/metal-block-storage-detach \
     /home/packet/
 
 COPY entrypoint.sh /entrypoint.sh

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -445,6 +445,8 @@ EOF
 	set_autofail_stage "misc post-install tasks"
 	echo -e "${GREEN}#### Run misc post-install tasks${NC}"
 	install -m755 -o root -g root /home/packet/metal-block-storage-* $target/usr/bin
+	ln -nsf /usr/bin/metal-block-storage-attach  $target/usr/bin/packet-block-storage-attach
+	ln -nsf /usr/bin/metal-block-storage-detach  $target/usr/bin/packet-block-storage-detach
 	if [ -f $target/usr/sbin/policy-rc.d ]; then
 		echo "Removing policy-rc.d from target OS."
 		rm -f $target/usr/sbin/policy-rc.d

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -445,8 +445,8 @@ EOF
 	set_autofail_stage "misc post-install tasks"
 	echo -e "${GREEN}#### Run misc post-install tasks${NC}"
 	install -m755 -o root -g root /home/packet/metal-block-storage-* $target/usr/bin
-	ln -nsf /usr/bin/metal-block-storage-attach  $target/usr/bin/packet-block-storage-attach
-	ln -nsf /usr/bin/metal-block-storage-detach  $target/usr/bin/packet-block-storage-detach
+	ln -nsf /usr/bin/metal-block-storage-attach $target/usr/bin/packet-block-storage-attach
+	ln -nsf /usr/bin/metal-block-storage-detach $target/usr/bin/packet-block-storage-detach
 	if [ -f $target/usr/sbin/policy-rc.d ]; then
 		echo "Removing policy-rc.d from target OS."
 		rm -f $target/usr/sbin/policy-rc.d

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -444,7 +444,7 @@ EOF
 
 	set_autofail_stage "misc post-install tasks"
 	echo -e "${GREEN}#### Run misc post-install tasks${NC}"
-	install -m755 -o root -g root /home/packet/packet-block-storage-* $target/usr/bin
+	install -m755 -o root -g root /home/packet/metal-block-storage-* $target/usr/bin
 	if [ -f $target/usr/sbin/policy-rc.d ]; then
 		echo "Removing policy-rc.d from target OS."
 		rm -f $target/usr/sbin/policy-rc.d


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

This changes the naming on packet-block-storage scripts to metal-block-storage for Equinix Metal rebranding

<!--- Link to issue you have raised -->

## How Has This Been Tested?
Automated testing via drone CI


## How are existing users impacted? What migration steps/scripts do we need?

None. Symlinks are created with the deprecated naming.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
