### PR TITLE
Add support for the latest tink-worker udpate that changed the env variable used for the worker ID

### DIFF
--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -62,9 +62,13 @@ rm -f /sbin/mdev
 
 mkdir /worker
 
+# tink-worker has been updated to use ID rather than WORKER_ID
+# TODO: remove setting WORKER_ID when we no longer want to support backwards compatibility
+# with the older tink-worker
 docker run --privileged -t --name "tink-worker" \
 	-e "container_uuid=$id" \
 	-e "WORKER_ID=$worker_id" \
+	-e "ID=$worker_id" \
 	-e "DOCKER_REGISTRY=$docker_registry" \
 	-e "TINKERBELL_GRPC_AUTHORITY=$grpc_authority" \
 	-e "TINKERBELL_CERT_URL=$grpc_cert_url" \


### PR DESCRIPTION
## Description

Adds support for the latest tink-worker changes to command line arguments/env variables after https://github.com/tinkerbell/tink/pull/287 merged

## Why is this needed

Testing using the latest published images is broken, since tink-worker is looking for the ID env variable rather than WORKER_ID, this PR adds forward and backward compatible support.

## How Has This Been Tested?

Currently testing now using the tilt configuration I'm working on in https://github.com/detiber/tink/tree/kindDev, but it could also be tested using the vagrant or terraform setups with the changes needed to point to an osie build.

## How are existing users impacted? What migration steps/scripts do we need?

No additional migrations or scripts should be needed, it should not impact users.

