### PR TITLE
Add f3.medium GRUB templates

### DIFF
--- a/grub/centos_7-f3.medium.x86-grub.template
+++ b/grub/centos_7-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'CentOS' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'CentOS - single user mode' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		initrd /boot/initrd
+}

--- a/grub/centos_7-f3.medium.x86-grub.template.default
+++ b/grub/centos_7-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/centos_8-f3.medium.x86-grub.template
+++ b/grub/centos_8-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'CentOS' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'CentOS - single user mode' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		initrd /boot/initrd
+}

--- a/grub/centos_8-f3.medium.x86-grub.template.default
+++ b/grub/centos_8-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-f3.medium.x86-grub.template
+++ b/grub/debian_10-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_10-f3.medium.x86-grub.template.default
+++ b/grub/debian_10-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_8-f3.medium.x86-grub.template
+++ b/grub/debian_8-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/debian_8-f3.medium.x86-grub.template.default
+++ b/grub/debian_8-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_9-f3.medium.x86-grub.template
+++ b/grub/debian_9-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/debian_9-f3.medium.x86-grub.template.default
+++ b/grub/debian_9-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/opensuse_42_3-f3.medium.x86-grub.template
+++ b/grub/opensuse_42_3-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'OpenSUSE' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'OpenSUSE - single user mode' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		initrd /boot/initrd
+}

--- a/grub/opensuse_42_3-f3.medium.x86-grub.template.default
+++ b/grub/opensuse_42_3-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/rhel_7-f3.medium.x86-grub.template
+++ b/grub/rhel_7-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'RHEL' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'RHEL - single user mode' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		initrd /boot/initrd
+}

--- a/grub/rhel_7-f3.medium.x86-grub.template.default
+++ b/grub/rhel_7-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/rhel_8-f3.medium.x86-grub.template
+++ b/grub/rhel_8-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'RHEL' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'RHEL - single user mode' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		initrd /boot/initrd
+}

--- a/grub/rhel_8-f3.medium.x86-grub.template.default
+++ b/grub/rhel_8-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/scientific_6-f3.medium.x86-grub.template
+++ b/grub/scientific_6-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Scientific Linux 6' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Scientific Linux 6 - single user mode' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		initrd /boot/initrd
+}

--- a/grub/scientific_6-f3.medium.x86-grub.template.default
+++ b/grub/scientific_6-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/suse_sles12_sp3-f3.medium.x86-grub.template
+++ b/grub/suse_sles12_sp3-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'SUSE' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'SUSE - single user mode' --class rhel fedora --class gnu-linux --class gnu --class os {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		initrd /boot/initrd
+}

--- a/grub/suse_sles12_sp3-f3.medium.x86-grub.template.default
+++ b/grub/suse_sles12_sp3-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_14_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_14_04-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_14_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_14_04-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_16_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_16_04-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_16_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_16_04-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_17_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_17_04-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_17_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_17_04-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_17_10-f3.medium.x86-grub.template
+++ b/grub/ubuntu_17_10-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_17_10-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_17_10-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_18_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_18_04-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_18_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_18_04-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_19_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_19_04-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_19_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_19_04-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_19_10-f3.medium.x86-grub.template
+++ b/grub/ubuntu_19_10-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_19_10-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_19_10-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_20_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_20_04-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_20_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_20_04-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_20_10-f3.medium.x86-grub.template
+++ b/grub/ubuntu_20_10-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_20_10-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_20_10-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template
+++ b/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'VMware NSX' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'VMware NSX - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template.default
+++ b/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template
+++ b/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'VMware NSX' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'VMware NSX - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template.default
+++ b/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'


### PR DESCRIPTION
## Description

Adds in the GRUB templates for a new plan type, the f3.medium

## Why is this needed

Without these files, OS installations on this plan type do not succeed.

## How Has This Been Tested?
Barely, just following previous patterns.


## How are existing users impacted? What migration steps/scripts do we need?
No break, just fix. 🤞 
