### PR TITLE
Add Discovery OS mode

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,6 +107,8 @@ pipeline:
       - mc config host add s3 'https://s3.amazonaws.com' "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" --api s3v4
       - set +v -x
       - make deploy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     when:
       event:
         - push
@@ -122,6 +124,8 @@ pipeline:
       - mc config host add s3 'https://s3.amazonaws.com' "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" --api s3v4
       - set +v -x
       - make deploy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     when:
       event:
         - pull_request

--- a/apps/discover-rc
+++ b/apps/discover-rc
@@ -1,0 +1,5 @@
+#!/sbin/openrc-run
+
+name="Equinix Metal Discovery OS"
+command="/etc/init.d/sshd start; /sbin/discover"
+command_args="$DISCOVER_OPTS"

--- a/apps/discover.sh
+++ b/apps/discover.sh
@@ -1,0 +1,77 @@
+#!/bin/ash
+
+# shellcheck shell=dash
+
+arch=$(uname -m)
+packet_base_url=$(sed -nr 's|.*\bpacket_base_url=(\S+).*|\1|p' /proc/cmdline)
+facility=$(sed -nr 's|.*\bfacility=(\S+).*|\1|p' /proc/cmdline)
+tinkerbell=$(sed -nr 's|.*\btinkerbell=(\S+).*|\1|p' /proc/cmdline | sed -e 's|^http://||' -e 's|/.*||')
+phone_home_url="http://$tinkerbell/phone-home"
+
+discover_url=$(sed -nr 's|.*\bdiscover_url=(\S+).*|\1|p' /proc/cmdline)
+if [ -z "$discover_url" ]; then
+	discover_url="http://$tinkerbell/discover-os"
+fi
+
+reason='unknown'
+fail() {
+	curl -H 'Content-Type: application/json' \
+		-d '{"type":"failure", "reason":"'"$reason"'"}' \
+		"$phone_home_url"
+}
+
+# shellcheck disable=SC2039
+set -o errexit -o pipefail -o xtrace
+
+# Create rescue motd
+cat <<'EOF' >/etc/motd
+    ,------.               ,--.        ,--.                       
+    |  .---' ,---. ,--.,--.`--',--,--, `--',--.  ,--.             
+    |  `--, | .-. ||  ||  |,--.|      \,--. \  `'  /              
+    |  `---.' '-' |'  ''  '|  ||  ||  ||  | /  /.  \              
+    `------' `-|  | `----' `--'`--''--'`--''--'  '--'             
+,------.  ,--. `--'                                               
+|  .-.  \ `--' ,---.  ,---. ,---.,--.  ,--.,---. ,--.--.,--. ,--. 
+|  |  \  :,--.(  .-' | .--'| .-. |\  `'  /| .-. :|  .--' \  '  /  
+|  '--'  /|  |.-'  `)\ `--.' '-' ' \    / \   --.|  |     \   '   
+`-------' `--'`----'  `---' `---'   `--'   `----'`--'   .-'  /    
+                                                        `---'     
+=================================================================
+       Discovery environment based on Ubuntu Xenial
+EOF
+
+mkdir -p /root/.ssh
+
+curl -X POST -vs "$phone_home_url" 2>&1 | logger -t phone_home
+
+mdadm --assemble --scan || :
+
+service cgroups start
+service docker start
+
+until docker info; do
+	echo 'Waiting for docker to respond...'
+	sleep 3
+done
+
+reason='unable to load discover container image'
+if ! docker images "quay.io/packet/discover-metal" | grep discover >/dev/null; then
+	curl "${packet_base_url:-http://install.$facility.packet.net/misc/osie/current}/discover-metal-$arch.tar.gz" |
+		docker load |
+		tee
+fi
+
+# stop mdev from messing with us once and for all
+rm -f /sbin/mdev
+
+cat <<'EOF' >/bin/discover-shell
+#!/bin/sh
+docker run --privileged --entrypoint bash -it quay.io/packet/discover-metal
+EOF
+chmod +x /bin/discover-shell
+
+reason='docker exited with an error'
+docker run --privileged -ti \
+	-v /dev:/dev \
+	--net host \
+	quay.io/packet/discover-metal --send "$discover_url"

--- a/installer/alpine/init-aarch64
+++ b/installer/alpine/init-aarch64
@@ -300,6 +300,9 @@ ebegin "Verifying required kernel cmdline arguments"
 [ -z $KOPT_facility ] && eend 1 "missing required argument: facility"
 [ -z $KOPT_packet_action ] && eend 1 "missing required argument: packet_action"
 case $KOPT_packet_action in
+discover)
+  packet_action=discover
+  ;;
 install)
 	packet_action=osie-installer
 	;;

--- a/installer/alpine/init-x86_64
+++ b/installer/alpine/init-x86_64
@@ -377,6 +377,7 @@ ebegin "Verifying required kernel cmdline arguments"
 [ -z $KOPT_facility ] && eend 1 "missing required argument: facility"
 [ -z $KOPT_packet_action ] && eend 1 "missing required argument: packet_action"
 case $KOPT_packet_action in
+discover) packet_action=discover ;;
 install) packet_action=osie-installer ;;
 rescue) packet_action=rescue-helper ;;
 workflow) packet_action=workflow-helper ;;

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -68,10 +68,11 @@ v:
 
 packaged-apps := $(subst apps/,build/$v/,${apps})
 packaged-grubs := $(addprefix build/$v/,$(subst -,/,${grubs}))
+packaged-discover-metals := build/$v/discover-metal-x86_64.tar.gz
 packaged-osie-runners := build/$v/osie-runner-x86_64.tar.gz
 packaged-osies := build/$v/osie-aarch64.tar.gz build/$v/osie-x86_64.tar.gz
 packaged-repos := build/$v/repo-aarch64 build/$v/repo-x86_64
-packages := ${packaged-apps} ${packaged-grubs} ${packaged-osie-runners} ${packaged-osies} ${packaged-repos}
+packages := ${packaged-apps} ${packaged-grubs} ${packaged-discover-metals} ${packaged-osie-runners} ${packaged-osies} ${packaged-repos}
 
 .PHONY:{% for platform in platforms.keys() %} package-{{platform}}
 {%- endfor %}
@@ -137,7 +138,7 @@ build/$v/%.sh: apps/%.sh
 	$(E) "INSTALL  $@"
 	$(Q) install -D -m644 $< $@
 
-build/$v/osie-%: build/osie-%
+build/$v/%.tar.gz: build/%.tar.gz
 	$(E) "INSTALL  $@"
 	$(Q) install -D -m644 $< $@
 
@@ -204,6 +205,12 @@ build/$v-rootfs-%: build/initramfs-%
 	$(Q) rm -rf $@
 	$(Q) mkdir $@
 	$(Q) bsdtar -xf $< -C $@
+
+build/discover-metal-x86_64.tar.gz:
+	$(E) "DOCKER   $@"
+	$(Q) docker pull quay.io/packet/discover-metal 2>&1 | tee $@.log >/dev/$T
+	$(Q) docker save quay.io/packet/discover-metal:latest > $@.tmp
+	$(Q) mv $@.tmp $@
 
 ifneq ($(CI),drone)
 build/osie-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64


### PR DESCRIPTION
Discovery OS is a new mode of OSIE that offers various tools to
auto-detect and setup hardware during initial rack enrollment of a
server.
    
It's based on the packet/discover-metal container image we have
hosted on quay.io. During the OSIE build process we download this image
so it can be available during OSIE runs without having to retrieve it
via quay.
