### PR TITLE
f3: add kexec bypass

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -619,6 +619,8 @@ ubuntu_20_04:t1.small.x86) reboot=true ;;
 ubuntu_16_04:c3.medium.x86) reboot=true ;;
 ubuntu_16_04:t3.small.x86) reboot=true ;;
 *:c2.medium.x86) reboot=true ;;
+*:f3.large.x86) reboot=true ;;
+*:f3.medium.x86) reboot=true ;;
 esac
 
 if ${reboot:-false}; then


### PR DESCRIPTION
## Description

Lets bypass kexec for the f3 medium and f3 large

## Why is this needed

The installation did not finish properly because the server hung when the kexec was attempted.
So lets just reboot instead of kexec'ing which seemed to work just fine 🙂 