### PR TITLE
Add BIOS utilities to OSIE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -144,6 +144,14 @@ RUN cd /tmp/osie && \
     fi && \
     rm -rf /tmp/osie
 
+# SuperMicro SUM
+COPY lfs/sum_2.4.0_Linux_x86_64_20191206.tar.gz /tmp/osie/
+RUN if [ $(uname -m) = 'x86_64' ]; then \
+      mkdir -p /opt/supermicro && \
+        tar -zxvf /tmp/osie/sum_2.4.0_Linux_x86_64_20191206.tar.gz -C /opt/supermicro && \
+        ln -s /opt/supermicro/sum_2.4.0_Linux_x86_64 /opt/supermicro/sum; \
+    fi ;
+
 # URL=http://www.mellanox.com/downloads/firmware/mlxup
 # VERSION=4.6.0
 COPY lfs/mlxup-* /tmp/osie/

--- a/docker/lfs/sum_2.4.0_Linux_x86_64_20191206.tar.gz
+++ b/docker/lfs/sum_2.4.0_Linux_x86_64_20191206.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0d7203913334e02d4ea1c8493834c5a0e7236040380447e22697b816dc614c7
+size 9732263


### PR DESCRIPTION
sum is used to update SuperMicro server BIOS and BMC firmware.