### PR TITLE
Switch f3 GRUB templates to ttyS0

### DIFF
--- a/grub/centos_7-f3.large.x86-grub.template
+++ b/grub/centos_7-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'CentOS' --class rhel fedora --class gnu-linux --class gnu --class os 
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'CentOS - single user mode' --class rhel fedora --class gnu-linux --cl
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/centos_7-f3.large.x86-grub.template.default
+++ b/grub/centos_7-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/centos_7-f3.medium.x86-grub.template
+++ b/grub/centos_7-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'CentOS' --class rhel fedora --class gnu-linux --class gnu --class os 
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'CentOS - single user mode' --class rhel fedora --class gnu-linux --cl
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/centos_7-f3.medium.x86-grub.template.default
+++ b/grub/centos_7-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/centos_8-f3.large.x86-grub.template
+++ b/grub/centos_8-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'CentOS' --class rhel fedora --class gnu-linux --class gnu --class os 
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'CentOS - single user mode' --class rhel fedora --class gnu-linux --cl
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/centos_8-f3.large.x86-grub.template.default
+++ b/grub/centos_8-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/centos_8-f3.medium.x86-grub.template
+++ b/grub/centos_8-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'CentOS' --class rhel fedora --class gnu-linux --class gnu --class os 
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'CentOS - single user mode' --class rhel fedora --class gnu-linux --cl
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/centos_8-f3.medium.x86-grub.template.default
+++ b/grub/centos_8-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-f3.large.x86-grub.template
+++ b/grub/debian_10-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-f3.large.x86-grub.template.default
+++ b/grub/debian_10-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_10-f3.medium.x86-grub.template
+++ b/grub/debian_10-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/debian_10-f3.medium.x86-grub.template.default
+++ b/grub/debian_10-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_8-f3.large.x86-grub.template
+++ b/grub/debian_8-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/debian_8-f3.large.x86-grub.template.default
+++ b/grub/debian_8-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_8-f3.medium.x86-grub.template
+++ b/grub/debian_8-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/debian_8-f3.medium.x86-grub.template.default
+++ b/grub/debian_8-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_9-f3.large.x86-grub.template
+++ b/grub/debian_9-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/debian_9-f3.large.x86-grub.template.default
+++ b/grub/debian_9-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_9-f3.medium.x86-grub.template
+++ b/grub/debian_9-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/debian_9-f3.medium.x86-grub.template.default
+++ b/grub/debian_9-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/opensuse_42_3-f3.large.x86-grub.template
+++ b/grub/opensuse_42_3-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'OpenSUSE' --class rhel fedora --class gnu-linux --class gnu --class o
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'OpenSUSE - single user mode' --class rhel fedora --class gnu-linux --
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/opensuse_42_3-f3.large.x86-grub.template.default
+++ b/grub/opensuse_42_3-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/opensuse_42_3-f3.medium.x86-grub.template
+++ b/grub/opensuse_42_3-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'OpenSUSE' --class rhel fedora --class gnu-linux --class gnu --class o
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'OpenSUSE - single user mode' --class rhel fedora --class gnu-linux --
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/opensuse_42_3-f3.medium.x86-grub.template.default
+++ b/grub/opensuse_42_3-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/rhel_7-f3.large.x86-grub.template
+++ b/grub/rhel_7-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'RHEL' --class rhel fedora --class gnu-linux --class gnu --class os {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'RHEL - single user mode' --class rhel fedora --class gnu-linux --clas
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/rhel_7-f3.large.x86-grub.template.default
+++ b/grub/rhel_7-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/rhel_7-f3.medium.x86-grub.template
+++ b/grub/rhel_7-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'RHEL' --class rhel fedora --class gnu-linux --class gnu --class os {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'RHEL - single user mode' --class rhel fedora --class gnu-linux --clas
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/rhel_7-f3.medium.x86-grub.template.default
+++ b/grub/rhel_7-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/rhel_8-f3.large.x86-grub.template
+++ b/grub/rhel_8-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'RHEL' --class rhel fedora --class gnu-linux --class gnu --class os {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'RHEL - single user mode' --class rhel fedora --class gnu-linux --clas
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/rhel_8-f3.large.x86-grub.template.default
+++ b/grub/rhel_8-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/rhel_8-f3.medium.x86-grub.template
+++ b/grub/rhel_8-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'RHEL' --class rhel fedora --class gnu-linux --class gnu --class os {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'RHEL - single user mode' --class rhel fedora --class gnu-linux --clas
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/rhel_8-f3.medium.x86-grub.template.default
+++ b/grub/rhel_8-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/scientific_6-f3.large.x86-grub.template
+++ b/grub/scientific_6-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Scientific Linux 6' --class rhel fedora --class gnu-linux --class gnu
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Scientific Linux 6 - single user mode' --class rhel fedora --class gn
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/scientific_6-f3.large.x86-grub.template.default
+++ b/grub/scientific_6-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/scientific_6-f3.medium.x86-grub.template
+++ b/grub/scientific_6-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Scientific Linux 6' --class rhel fedora --class gnu-linux --class gnu
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Scientific Linux 6 - single user mode' --class rhel fedora --class gn
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/scientific_6-f3.medium.x86-grub.template.default
+++ b/grub/scientific_6-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/suse_sles12_sp3-f3.large.x86-grub.template
+++ b/grub/suse_sles12_sp3-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'SUSE' --class rhel fedora --class gnu-linux --class gnu --class os {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'SUSE - single user mode' --class rhel fedora --class gnu-linux --clas
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/suse_sles12_sp3-f3.large.x86-grub.template.default
+++ b/grub/suse_sles12_sp3-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/suse_sles12_sp3-f3.medium.x86-grub.template
+++ b/grub/suse_sles12_sp3-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'SUSE' --class rhel fedora --class gnu-linux --class gnu --class os {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'SUSE - single user mode' --class rhel fedora --class gnu-linux --clas
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1 single
 		initrd /boot/initrd
 }

--- a/grub/suse_sles12_sp3-f3.medium.x86-grub.template.default
+++ b/grub/suse_sles12_sp3-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 rd.auto rd.auto=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_14_04-f3.large.x86-grub.template
+++ b/grub/ubuntu_14_04-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_14_04-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_14_04-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_14_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_14_04-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_14_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_14_04-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_16_04-f3.large.x86-grub.template
+++ b/grub/ubuntu_16_04-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_16_04-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_16_04-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_16_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_16_04-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_16_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_16_04-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_17_04-f3.large.x86-grub.template
+++ b/grub/ubuntu_17_04-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_17_04-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_17_04-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_17_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_17_04-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_17_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_17_04-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_17_10-f3.large.x86-grub.template
+++ b/grub/ubuntu_17_10-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_17_10-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_17_10-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_17_10-f3.medium.x86-grub.template
+++ b/grub/ubuntu_17_10-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_17_10-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_17_10-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_18_04-f3.large.x86-grub.template
+++ b/grub/ubuntu_18_04-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_18_04-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_18_04-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_18_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_18_04-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_18_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_18_04-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8 biosdevname=0 net.ifnames=1'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_19_04-f3.large.x86-grub.template
+++ b/grub/ubuntu_19_04-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_19_04-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_19_04-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_19_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_19_04-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_19_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_19_04-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_19_10-f3.large.x86-grub.template
+++ b/grub/ubuntu_19_10-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_19_10-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_19_10-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_19_10-f3.medium.x86-grub.template
+++ b/grub/ubuntu_19_10-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_19_10-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_19_10-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_20_04-f3.large.x86-grub.template
+++ b/grub/ubuntu_20_04-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_20_04-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_20_04-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_20_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_20_04-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_20_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_20_04-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_20_10-f3.large.x86-grub.template
+++ b/grub/ubuntu_20_10-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_20_10-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_20_10-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_20_10-f3.medium.x86-grub.template
+++ b/grub/ubuntu_20_10-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class g
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/ubuntu_20_10-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_20_10-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/vmware_nsx_2_5_0-f3.large.x86-grub.template
+++ b/grub/vmware_nsx_2_5_0-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'VMware NSX' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'VMware NSX - single user mode' --class ubuntu --class gnu-linux --cla
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/vmware_nsx_2_5_0-f3.large.x86-grub.template.default
+++ b/grub/vmware_nsx_2_5_0-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template
+++ b/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'VMware NSX' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'VMware NSX - single user mode' --class ubuntu --class gnu-linux --cla
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template.default
+++ b/grub/vmware_nsx_2_5_0-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/vmware_nsx_3_0_0-f3.large.x86-grub.template
+++ b/grub/vmware_nsx_3_0_0-f3.large.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'VMware NSX' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'VMware NSX - single user mode' --class ubuntu --class gnu-linux --cla
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/vmware_nsx_3_0_0-f3.large.x86-grub.template.default
+++ b/grub/vmware_nsx_3_0_0-f3.large.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template
+++ b/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template
@@ -15,7 +15,7 @@ set default=0
 #set root='(hd0,1)'
 
 # Define console settings
-#serial console=tty0 console=ttyS1,115200n8
+#serial console=tty0 console=ttyS0,115200n8
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 terminal --timeout=10 serial console
 
@@ -46,7 +46,7 @@ menuentry 'VMware NSX' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 
@@ -66,6 +66,6 @@ menuentry 'VMware NSX - single user mode' --class ubuntu --class gnu-linux --cla
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
 		initrd /boot/initrd
 }

--- a/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template.default
+++ b/grub/vmware_nsx_3_0_0-f3.medium.x86-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'


### PR DESCRIPTION
## Description

Lets change the two f3 plans to utilize ttyS0 instead of ttyS1

## Why is this needed

Seems HP ships servers with this as their default TTY

## How Has This Been Tested?

Credit to @dlaube for helping sort out which TTY was in use 👍 

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix 🤞 
