### PR TITLE
Add ssacli and use it in smartarray_reset

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,6 +120,14 @@ RUN cd /tmp/osie && \
     cd && \
     rm -r /tmp/osie
 
+# SSA CLI
+RUN if [ $(uname -m) = 'x86_64' ]; then \
+      temp="$(mktemp)" && \
+      wget -O "$temp" 'https://downloads.linux.hpe.com/SDR/repo/mcp/pool/non-free/ssacli-4.17-6.0_amd64.deb' && \
+      dpkg -i "$temp" && \
+      rm -rf "$temp"; \
+    fi ;
+
 # IPMICFG
 COPY lfs/ipmicfg /tmp/osie/
 RUN cd /tmp/osie && \

--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -200,6 +200,12 @@ if [[ $preserve_data == false ]]; then
 			[[ -z ${DISKS:-} ]] && disks=($(lsblk -dno name -e1,7,11 | sed 's|^|/dev/|' | sort))
 		fi
 	fi
+
+	# Adaptec Smart Storage (HPE)
+	set_autofail_stage "checking/resetting Adaptec Smart Storage RAID logical drives"
+	if lspci -nn | grep 'Adaptec Smart Storage PQI' >/dev/null && [[ $arch == x86_64 ]]; then
+		smartarray_reset
+	fi
 else
 	echo "Skipped array reset due to preserve_data: true"
 fi

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -519,6 +519,23 @@ function perc_reset() {
 	fi
 }
 
+function smartarray_reset() {
+	systemmfg=$(dmidecode -s system-manufacturer | head -1)
+	echo "Adaptec hardware RAID device is present on system mfg: $systemmfg"
+
+	slots=$(ssacli ctrl all show detail | awk '/^   Slot: / {print $2}')
+
+	echo "Adaptec smart storage array, clearing logical drives"
+	for slot in $slots; do
+		if ssacli controller slot="$slot" logicaldrive all show status >/dev/null; then
+			echo "Clearing logical drives for slot $slot"
+			ssacli controller slot="$slot" logicaldrive all delete forced
+		else
+			echo "Controller slot $slot has no logical drives, skipping"
+		fi
+	done
+}
+
 # megaraid_reset uses MegaCli64 to reset the raid card to JBODs
 # usage: megaraid_reset disk...
 function megaraid_reset() {


### PR DESCRIPTION
## Description

Lets add in SSACLI and we'll use it for breaking apart logical drives

## Why is this needed

Logical drives get in the way of deprovisioning, so lets destroy them

## How Has This Been Tested?
Just barely

## How are existing users impacted? What migration steps/scripts do we need?
No break, only fix 🤞 
