### PR TITLE
Probe and print BIOS vendor and version on deprov

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -61,7 +61,13 @@ function autofail() {
 }
 trap autofail EXIT
 
-# Pre-deprov check
+# Check BIOS config and update if drift is detected
+if [[ $arch == x86_64 ]]; then
+	set_autofail_stage "BIOS config validation"
+	print_bios_version_info
+fi
+
+# Storage detection
 set_autofail_stage "drive count and storage size detection"
 echo "Number of drives found: ${#disks[*]}"
 if ! assert_num_disks "$class" "${#disks[@]}"; then


### PR DESCRIPTION
This currently only works for our Gen3 Dell and Supermicro servers as a
starting point. Eventually this will evolve into the ability to
validate BIOS configuration settings on deprov and reset them if drift
is detected.

This is WIP and I'm not sure this needs to be merged to master at all. I am however still interested in feedback on the approach itself and will test this as a custom OSIE version while doing further development.