### PR TITLE
Add deb11 and ub2104 grub templates

### DIFF
--- a/grub/debian_11-c1.large.arm-grub.template
+++ b/grub/debian_11-c1.large.arm-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Debian' --class debian --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'debian-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/debian_11-c1.large.arm-grub.template.default
+++ b/grub/debian_11-c1.large.arm-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/debian_11-c1.small.x86-grub.template
+++ b/grub/debian_11-c1.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-c1.small.x86-grub.template.default
+++ b/grub/debian_11-c1.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-c1.xlarge.x86-grub.template
+++ b/grub/debian_11-c1.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-c1.xlarge.x86-grub.template.default
+++ b/grub/debian_11-c1.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-c2.large.anbox-grub.template
+++ b/grub/debian_11-c2.large.anbox-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Debian' --class debian --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'debian-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/debian_11-c2.large.anbox-grub.template.default
+++ b/grub/debian_11-c2.large.anbox-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/debian_11-c2.large.arm-grub.template
+++ b/grub/debian_11-c2.large.arm-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Debian' --class debian --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'debian-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/debian_11-c2.large.arm-grub.template.default
+++ b/grub/debian_11-c2.large.arm-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/debian_11-c2.medium.x86-grub.template
+++ b/grub/debian_11-c2.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-c2.medium.x86-grub.template.default
+++ b/grub/debian_11-c2.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-c2.small.x86-grub.template
+++ b/grub/debian_11-c2.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-c2.small.x86-grub.template.default
+++ b/grub/debian_11-c2.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-c3.medium.x86-grub.template
+++ b/grub/debian_11-c3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-c3.medium.x86-grub.template.default
+++ b/grub/debian_11-c3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-c3.small.x86-grub.template
+++ b/grub/debian_11-c3.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-c3.small.x86-grub.template.default
+++ b/grub/debian_11-c3.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-cpe1.c1.r720xd-grub.template
+++ b/grub/debian_11-cpe1.c1.r720xd-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-cpe1.c1.r720xd-grub.template.default
+++ b/grub/debian_11-cpe1.c1.r720xd-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-f3.large.x86-grub.template
+++ b/grub/debian_11-f3.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS0,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-f3.large.x86-grub.template.default
+++ b/grub/debian_11-f3.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-f3.medium.x86-grub.template
+++ b/grub/debian_11-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS0,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-f3.medium.x86-grub.template.default
+++ b/grub/debian_11-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-g2.large.x86-grub.template
+++ b/grub/debian_11-g2.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-g2.large.x86-grub.template.default
+++ b/grub/debian_11-g2.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-m1.xlarge.x86-grub.template
+++ b/grub/debian_11-m1.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-m1.xlarge.x86-grub.template.default
+++ b/grub/debian_11-m1.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-m2.xlarge.x86-grub.template
+++ b/grub/debian_11-m2.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-m2.xlarge.x86-grub.template.default
+++ b/grub/debian_11-m2.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-m3.large.x86-grub.template
+++ b/grub/debian_11-m3.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-m3.large.x86-grub.template.default
+++ b/grub/debian_11-m3.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-n2.xlarge.google-grub.template
+++ b/grub/debian_11-n2.xlarge.google-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-n2.xlarge.google-grub.template.default
+++ b/grub/debian_11-n2.xlarge.google-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-n2.xlarge.x86-grub.template
+++ b/grub/debian_11-n2.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-n2.xlarge.x86-grub.template.default
+++ b/grub/debian_11-n2.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=igb'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-s1.large.x86-grub.template
+++ b/grub/debian_11-s1.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-s1.large.x86-grub.template.default
+++ b/grub/debian_11-s1.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-s2.large.x86-grub.template
+++ b/grub/debian_11-s2.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-s2.large.x86-grub.template.default
+++ b/grub/debian_11-s2.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-s3.xlarge.x86-grub.template
+++ b/grub/debian_11-s3.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-s3.xlarge.x86-grub.template.default
+++ b/grub/debian_11-s3.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-t1.small.x86-grub.template
+++ b/grub/debian_11-t1.small.x86-grub.template
@@ -1,0 +1,65 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class debian --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class debian --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-t1.small.x86-grub.template.default
+++ b/grub/debian_11-t1.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-t3.small.x86-grub.template
+++ b/grub/debian_11-t3.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-t3.small.x86-grub.template.default
+++ b/grub/debian_11-t3.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-t3.xsmall.x86-grub.template
+++ b/grub/debian_11-t3.xsmall.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-t3.xsmall.x86-grub.template.default
+++ b/grub/debian_11-t3.xsmall.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-x.large.arm-grub.template
+++ b/grub/debian_11-x.large.arm-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Debian' --class debian --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'debian-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/debian_11-x.large.arm-grub.template.default
+++ b/grub/debian_11-x.large.arm-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/debian_11-x.small.x86-grub.template
+++ b/grub/debian_11-x.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-x.small.x86-grub.template.default
+++ b/grub/debian_11-x.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-x1.small.x86-grub.template
+++ b/grub/debian_11-x1.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-x1.small.x86-grub.template.default
+++ b/grub/debian_11-x1.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-x2.graphcore.x86-grub.template
+++ b/grub/debian_11-x2.graphcore.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-x2.graphcore.x86-grub.template.default
+++ b/grub/debian_11-x2.graphcore.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/debian_11-x2.xlarge.x86-grub.template
+++ b/grub/debian_11-x2.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-x2.xlarge.x86-grub.template.default
+++ b/grub/debian_11-x2.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-baremetal_2a4-grub.template
+++ b/grub/ubuntu_21_04-baremetal_2a4-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-baremetal_2a4-grub.template.default
+++ b/grub/ubuntu_21_04-baremetal_2a4-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-baremetal_2a5-grub.template
+++ b/grub/ubuntu_21_04-baremetal_2a5-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA2,115200n8 earlycon=qdf2400_e44,0xff78ef1000 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-baremetal_2a5-grub.template.default
+++ b/grub/ubuntu_21_04-baremetal_2a5-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA2,115200n8 earlycon=qdf2400_e44,0xff78ef1000 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-baremetal_hua-grub.template
+++ b/grub/ubuntu_21_04-baremetal_hua-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-baremetal_hua-grub.template.default
+++ b/grub/ubuntu_21_04-baremetal_hua-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyS0,115200n8 biosdevname=0 net.ifnames=0 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-c1.large.arm-grub.template
+++ b/grub/ubuntu_21_04-c1.large.arm-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-c1.large.arm-grub.template.default
+++ b/grub/ubuntu_21_04-c1.large.arm-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-c1.large.arm.xda-grub.template
+++ b/grub/ubuntu_21_04-c1.large.arm.xda-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 pcie_aspm=off pci=pcie_bus_perf crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-c1.large.arm.xda-grub.template.default
+++ b/grub/ubuntu_21_04-c1.large.arm.xda-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 pcie_aspm=off pci=pcie_bus_perf crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-c1.small.x86-grub.template
+++ b/grub/ubuntu_21_04-c1.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-c1.small.x86-grub.template.default
+++ b/grub/ubuntu_21_04-c1.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-c1.xlarge.x86-grub.template
+++ b/grub/ubuntu_21_04-c1.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-c1.xlarge.x86-grub.template.default
+++ b/grub/ubuntu_21_04-c1.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-c2.large.anbox-grub.template
+++ b/grub/ubuntu_21_04-c2.large.anbox-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-c2.large.anbox-grub.template.default
+++ b/grub/ubuntu_21_04-c2.large.anbox-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-c2.large.arm-grub.template
+++ b/grub/ubuntu_21_04-c2.large.arm-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-c2.large.arm-grub.template.default
+++ b/grub/ubuntu_21_04-c2.large.arm-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200 iommu.passthrough=1 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-c2.medium.x86-grub.template
+++ b/grub/ubuntu_21_04-c2.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-c2.medium.x86-grub.template.default
+++ b/grub/ubuntu_21_04-c2.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-c2.small.x86-grub.template
+++ b/grub/ubuntu_21_04-c2.small.x86-grub.template
@@ -1,0 +1,65 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-c2.small.x86-grub.template.default
+++ b/grub/ubuntu_21_04-c2.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-c3.medium.x86-grub.template
+++ b/grub/ubuntu_21_04-c3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-c3.medium.x86-grub.template.default
+++ b/grub/ubuntu_21_04-c3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-c3.small.x86-grub.template
+++ b/grub/ubuntu_21_04-c3.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-c3.small.x86-grub.template.default
+++ b/grub/ubuntu_21_04-c3.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-cpe1.c1.r720xd-grub.template
+++ b/grub/ubuntu_21_04-cpe1.c1.r720xd-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-cpe1.c1.r720xd-grub.template.default
+++ b/grub/ubuntu_21_04-cpe1.c1.r720xd-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-cpe1.g1.4028gr-grub.template
+++ b/grub/ubuntu_21_04-cpe1.g1.4028gr-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-cpe1.g1.4028gr-grub.template.default
+++ b/grub/ubuntu_21_04-cpe1.g1.4028gr-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-cpe1.m2.r640-grub.template
+++ b/grub/ubuntu_21_04-cpe1.m2.r640-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-cpe1.m2.r640-grub.template.default
+++ b/grub/ubuntu_21_04-cpe1.m2.r640-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-cpe1.s1.r730-grub.template
+++ b/grub/ubuntu_21_04-cpe1.s1.r730-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-cpe1.s1.r730-grub.template.default
+++ b/grub/ubuntu_21_04-cpe1.s1.r730-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-d1f.optane.x86-grub.template
+++ b/grub/ubuntu_21_04-d1f.optane.x86-grub.template
@@ -1,0 +1,69 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Define console settings
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Or it can be set using grub2's builtin search feature like so:
+
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-d1f.optane.x86-grub.template.default
+++ b/grub/ubuntu_21_04-d1f.optane.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-d1p.optane.x86-grub.template
+++ b/grub/ubuntu_21_04-d1p.optane.x86-grub.template
@@ -1,0 +1,69 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Define console settings
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Or it can be set using grub2's builtin search feature like so:
+
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-d1p.optane.x86-grub.template.default
+++ b/grub/ubuntu_21_04-d1p.optane.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-f3.large.x86-grub.template
+++ b/grub/ubuntu_21_04-f3.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS0,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-f3.large.x86-grub.template.default
+++ b/grub/ubuntu_21_04-f3.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-f3.medium.x86-grub.template
+++ b/grub/ubuntu_21_04-f3.medium.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS0,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS0,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-f3.medium.x86-grub.template.default
+++ b/grub/ubuntu_21_04-f3.medium.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS0,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-g2.large.x86-grub.template
+++ b/grub/ubuntu_21_04-g2.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-g2.large.x86-grub.template.default
+++ b/grub/ubuntu_21_04-g2.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-m1.xlarge.x86-grub.template
+++ b/grub/ubuntu_21_04-m1.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-m1.xlarge.x86-grub.template.default
+++ b/grub/ubuntu_21_04-m1.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-m2.xlarge.x86-grub.template
+++ b/grub/ubuntu_21_04-m2.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-m2.xlarge.x86-grub.template.default
+++ b/grub/ubuntu_21_04-m2.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-m3.large.x86-grub.template
+++ b/grub/ubuntu_21_04-m3.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-m3.large.x86-grub.template.default
+++ b/grub/ubuntu_21_04-m3.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-n2.xlarge.google-grub.template
+++ b/grub/ubuntu_21_04-n2.xlarge.google-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-n2.xlarge.google-grub.template.default
+++ b/grub/ubuntu_21_04-n2.xlarge.google-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-n2.xlarge.x86-grub.template
+++ b/grub/ubuntu_21_04-n2.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-n2.xlarge.x86-grub.template.default
+++ b/grub/ubuntu_21_04-n2.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-s1.large.x86-grub.template
+++ b/grub/ubuntu_21_04-s1.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-s1.large.x86-grub.template.default
+++ b/grub/ubuntu_21_04-s1.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-s2.large.x86-grub.template
+++ b/grub/ubuntu_21_04-s2.large.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-s2.large.x86-grub.template.default
+++ b/grub/ubuntu_21_04-s2.large.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 modprobe.blacklist=ixgbe'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-s3.xlarge.x86-grub.template
+++ b/grub/ubuntu_21_04-s3.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-s3.xlarge.x86-grub.template.default
+++ b/grub/ubuntu_21_04-s3.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-t1.small.x86-grub.template
+++ b/grub/ubuntu_21_04-t1.small.x86-grub.template
@@ -1,0 +1,65 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-t1.small.x86-grub.template.default
+++ b/grub/ubuntu_21_04-t1.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-t3.small.x86-grub.template
+++ b/grub/ubuntu_21_04-t3.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-t3.small.x86-grub.template.default
+++ b/grub/ubuntu_21_04-t3.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-t3.xsmall.x86-grub.template
+++ b/grub/ubuntu_21_04-t3.xsmall.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-t3.xsmall.x86-grub.template.default
+++ b/grub/ubuntu_21_04-t3.xsmall.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-x.large.arm-grub.template
+++ b/grub/ubuntu_21_04-x.large.arm-grub.template
@@ -1,0 +1,121 @@
+
+### BEGIN /etc/grub.d/00_header ###
+set pager=1
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+if [ "${next_entry}" ] ; then
+   set default="${next_entry}"
+   set next_entry=
+   save_env next_entry
+   set boot_once=true
+else
+   set default="${saved_entry}"
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+export menuentry_id_option
+
+if [ "${prev_saved_entry}" ]; then
+  set saved_entry="${prev_saved_entry}"
+  save_env saved_entry
+  set prev_saved_entry=
+  save_env prev_saved_entry
+  set boot_once=true
+fi
+
+function savedefault {
+  if [ -z "${boot_once}" ]; then
+    saved_entry="${chosen}"
+    save_env saved_entry
+  fi
+}
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=5
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=5
+fi
+### END /etc/grub.d/00_header ###
+
+### BEGIN /etc/grub.d/00_tuned ###
+set tuned_params=""
+### END /etc/grub.d/00_tuned ###
+
+### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+
+### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Ubuntu Linux (aarch64)' --class Ubuntu --class gnu-linux --class gnu --class os --unrestricted $menuentry_id_option 'ubuntu-aarch64-PACKET_ROOT_UUID' {
+		load_video
+		insmod gzio
+		insmod part_gpt
+		insmod xfs
+		set root='hd0,gpt2'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint-ieee1275='ieee1275//disk@0,gpt2' --hint-bios=hd0,gpt2 --hint-efi=hd0,gpt2 --hint-baremetal=ahci0,gpt2  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8
+		initrd /boot/initrd
+}
+
+### END /etc/grub.d/10_linux ###
+
+### BEGIN /etc/grub.d/20_linux_xen ###
+### END /etc/grub.d/20_linux_xen ###
+
+### BEGIN /etc/grub.d/20_ppc_terminfo ###
+### END /etc/grub.d/20_ppc_terminfo ###
+
+### BEGIN /etc/grub.d/30_os-prober ###
+### END /etc/grub.d/30_os-prober ###
+
+### BEGIN /etc/grub.d/40_custom ###
+# This file provides an easy way to add custom menu entries.  Simply type the
+# menu entries you want to add after this comment.  Be careful not to change
+# the 'exec tail' line above.
+### END /etc/grub.d/40_custom ###
+
+### BEGIN /etc/grub.d/41_custom ###
+if [ -f  ${config_directory}/custom.cfg ]; then
+  source ${config_directory}/custom.cfg
+elif [ -z "${config_directory}" -a -f  $prefix/custom.cfg ]; then
+  source $prefix/custom.cfg;
+fi
+### END /etc/grub.d/41_custom ###

--- a/grub/ubuntu_21_04-x.large.arm-grub.template.default
+++ b/grub/ubuntu_21_04-x.large.arm-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=ttyAMA0,115200n8 crashkernel=auto LANG=en_US.UTF-8'
+GRUB_SERIAL_COMMAND='serial'

--- a/grub/ubuntu_21_04-x.small.x86-grub.template
+++ b/grub/ubuntu_21_04-x.small.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-x.small.x86-grub.template.default
+++ b/grub/ubuntu_21_04-x.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-x1.small.x86-grub.template
+++ b/grub/ubuntu_21_04-x1.small.x86-grub.template
@@ -1,0 +1,65 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod diskfilter
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-x1.small.x86-grub.template.default
+++ b/grub/ubuntu_21_04-x1.small.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-x2.graphcore.x86-grub.template
+++ b/grub/ubuntu_21_04-x2.graphcore.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-x2.graphcore.x86-grub.template.default
+++ b/grub/ubuntu_21_04-x2.graphcore.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-x2.xlarge.x86-grub.template
+++ b/grub/ubuntu_21_04-x2.xlarge.x86-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-x2.xlarge.x86-grub.template.default
+++ b/grub/ubuntu_21_04-x2.xlarge.x86-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'


### PR DESCRIPTION
## Description

Lets add GRUB templates for the upcoming Debian 11 and Ubuntu 21.04 releases

## Why is this needed

Required for successful provisions

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix 🤞 
