### PR TITLE
Update packet hardware and networking

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /tmp/osie/
 
 ARG PACKET_HARDWARE_COMMIT=bc24777799308f6e884fb9bfdaac398b5f39083f
-ARG PACKET_NETWORKING_COMMIT=dd13b2a94daace22ecd97f053b878dbfcf20cb80
+ARG PACKET_NETWORKING_COMMIT=2c201b2da0563ca9363f78170663c0baa6054e32
 
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 && \
     pip3 install git+https://github.com/packethost/packet-hardware.git@${PACKET_HARDWARE_COMMIT} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get update -y && \
     apt-get -qy clean && \
     rm -rf /var/lib/apt/lists/* /tmp/osie/
 
-ARG PACKET_HARDWARE_COMMIT=413cdf9392a7c962081403d942666152afd1d843
+ARG PACKET_HARDWARE_COMMIT=bc24777799308f6e884fb9bfdaac398b5f39083f
 ARG PACKET_NETWORKING_COMMIT=dd13b2a94daace22ecd97f053b878dbfcf20cb80
 
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 && \


### PR DESCRIPTION
## Description

Updates our packet-networking and packet-hardware utilities to their latest versions

## Why is this needed

Brings in HPE fixes and some future work for Debian 11 and Ubuntu 21.04

## How Has This Been Tested?
Individually but not as a whole yet


## How are existing users impacted? What migration steps/scripts do we need?
No break, only fix 🤞 