### PR TITLE
Apply BIOS config on deprov

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -72,7 +72,7 @@ if [[ $arch == x86_64 ]]; then
 	download_bios_configs
 
 	set_autofail_stage "validating BIOS config"
-	validate_bios_config "${bios_vendor}" "${class}"
+	validate_bios_config "${class}" "${bios_vendor}"
 fi
 
 # Storage detection

--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -56,7 +56,7 @@ function autofail() {
 	# shellcheck disable=SC2181
 	(($? == 0)) && exit
 
-	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"${autofail_stage}"'"}'
+	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"Error during ${autofail_stage}"'"}'
 	print_error_summary "${autofail_stage}"
 }
 trap autofail EXIT

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -285,10 +285,10 @@ function compare_bios_config_files() {
 	fi
 }
 
-# usage: validate_bios_config $vendor $plan
+# usage: validate_bios_config $plan $vendor
 function validate_bios_config() {
-	local vendor=$1
-	local plan=$2
+	local plan=$1
+	local vendor=$2
 	local config_file
 
 	# Check for a BIOS config for this plan

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -206,6 +206,12 @@ function retrieve_current_bios_config() {
 	elif [[ "${vendor}" == "Supermicro" ]]; then
 		/opt/supermicro/sum/sum -c GetCurrentBiosCfg --file current_bios.txt >/dev/null
 	fi
+
+	# Save a copy of the original BIOS config to /statedir in case we need to obtain
+	# it for troubleshooting issues.
+	if [[ -f current_bios.txt ]]; then
+		cp current_bios.txt /statedir/
+	fi
 }
 
 # usage: normalize_dell_bios_config_file $config_filename

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -68,7 +68,7 @@ function autofail() {
 	# shellcheck disable=SC2181
 	(($? == 0)) && exit
 
-	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"${autofail_stage}"'"}'
+	puttink "${tinkerbell}" phone-home '{"type":"failure", "reason":"'"Error during ${autofail_stage}"'"}'
 	print_error_summary "${autofail_stage}"
 }
 trap autofail EXIT


### PR DESCRIPTION
This builds upon the BIOS config validation on deprov work, and will apply the config for this plan if drift is detected and the enforcement status is set.