### PR TITLE
Skip BIOS validation process for BIOS configs tarball errors

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -70,10 +70,12 @@ if [[ $arch == x86_64 ]]; then
 	echo "BIOS detected: ${bios_vendor} ${bios_version}"
 
 	set_autofail_stage "downloading BIOS configs"
-	download_bios_configs
-
-	set_autofail_stage "validating BIOS config"
-	validate_bios_config "${class}" "${bios_vendor}"
+	if download_bios_configs; then
+		set_autofail_stage "validating BIOS config"
+		validate_bios_config "${class}" "${bios_vendor}"
+	else
+		echo "Skipping BIOS validation"
+	fi
 fi
 
 # Storage detection

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -154,14 +154,26 @@ function download_bios_configs() {
 	configure_image_cache_dns
 
 	echo "Downloading latest BIOS configurations"
-	curl --fail https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz --output bios-configs-latest.tar.gz
-	curl --fail https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz.sha256 --output bios-configs-latest.tar.gz.sha256
+	if ! curl --fail https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz --output bios-configs-latest.tar.gz; then
+		echo "Error: Download of BIOS configs tarball failed"
+		return 1
+	fi
+	if ! curl --fail https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz.sha256 --output bios-configs-latest.tar.gz.sha256; then
+		echo "Error: Download of BIOS configs checksum file failed"
+		return 1
+	fi
 
 	echo "Verifying BIOS configurations tarball"
-	sha256sum --check bios-configs-latest.tar.gz.sha256
+	if ! sha256sum --check bios-configs-latest.tar.gz.sha256; then
+		echo "Error: Verifying checksum of BIOS configs tarball failed"
+		return 1
+	fi
 
 	echo "Extracting BIOS configurations tarball"
-	tar -zxf bios-configs-latest.tar.gz
+	if ! tar -zxf bios-configs-latest.tar.gz; then
+		echo "Error: Extracting BIOS configs tarball failed"
+		return 1
+	fi
 }
 
 # usage: lookup_bios_config $plan $vendor


### PR DESCRIPTION
Since we download the BIOS configs tarball via IPN and it's a small file
to begin with (under 1 MB), download failures could indicate a
networking issue. It is recommended to configure log alerts based on
these error messages.