### PR TITLE
Skip BIOS validation for reserved hardware and check manifest for enforcement status

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -37,6 +37,7 @@ assert_all_args_consumed "$OPTIND" "$@"
 
 declare facility && set_from_metadata facility 'facility' <"$metadata"
 declare class && set_from_metadata class 'class' <"$metadata"
+declare reserved && set_from_metadata reserved 'reserved' <"$metadata"
 declare tinkerbell && set_from_metadata tinkerbell 'phone_home_url' <"$metadata"
 declare id && set_from_metadata id 'id' <"$metadata"
 declare preserve_data && set_from_metadata preserve_data 'preserve_data' false <"$metadata"
@@ -63,7 +64,7 @@ function autofail() {
 trap autofail EXIT
 
 # Check BIOS config and update if drift is detected
-if [[ $arch == x86_64 ]]; then
+if [[ $arch == x86_64 ]] && [[ $reserved != "true" ]]; then
 	set_autofail_stage "detecting BIOS information"
 	bios_vendor=$(detect_bios_vendor)
 	bios_version=$(detect_bios_version "${bios_vendor}")

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -154,8 +154,14 @@ function download_bios_configs() {
 	configure_image_cache_dns
 
 	echo "Downloading latest BIOS configurations"
-	curl --fail https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz --output bios-configs-latest.tar.gz
-	curl --fail https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz.sha256 --output bios-configs-latest.tar.gz.sha256
+	curl \
+		--fail \
+		--retry 3 \
+		https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz --output bios-configs-latest.tar.gz
+	curl \
+		--fail \
+		--retry 3 \
+		https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz.sha256 --output bios-configs-latest.tar.gz.sha256
 
 	echo "Verifying BIOS configurations tarball"
 	sha256sum --check bios-configs-latest.tar.gz.sha256

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -324,6 +324,7 @@ function validate_bios_config() {
 	local plan=$1
 	local vendor=$2
 	local config_file
+	local enforcement_status
 
 	# Check for a BIOS config for this plan
 	config_file=$(lookup_bios_config "${plan}" "${vendor}")
@@ -359,8 +360,14 @@ function validate_bios_config() {
 	set_autofail_stage "comparing current BIOS config with expected values"
 	compare_bios_config_files "bios-configs-latest/${config_file}" "${plan}"
 
-	set_autofail_stage "applying BIOS config"
-	apply_bios_config "${vendor}" "bios-configs-latest/${config_file}"
+	enforcement_status=$(lookup_bios_config_enforcement "${plan}" "${vendor}")
+	if [[ $enforcement_status != "enforce" ]]; then
+		set_autofail_stage "applying BIOS config"
+		apply_bios_config "${vendor}" "bios-configs-latest/${config_file}"
+	else
+		echo "BIOS config enforcment status is ${enforcement_status} for plan ${plan}, not applying config"
+		return 0
+	fi
 }
 
 function dns_resolvers() {

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -315,7 +315,7 @@ function apply_bios_config() {
 		/opt/dell/srvadmin/bin/idracadm7 set -b Forced -f "${config_file}" -t JSON
 	elif [[ ${vendor} == "Supermicro" ]]; then
 		echo "Applying Supermicro BIOS configuration ${config_file}..."
-		/opt/supermicro/sum/sum -c ChangeBiosCfg --file "${config_file}"
+		/opt/supermicro/sum/sum -c ChangeBiosCfg --skip_unknown --file "${config_file}"
 	fi
 }
 


### PR DESCRIPTION
Reserved hardware can have custom BIOS configs that we don't want to
touch. At some point we'll want to have finer grained metadata on what
BIOS config to use as a source of truth, but for now we simply won't
apply BIOS configs to reserved hardware devices.

In the bios configs tarball we have a manifest.txt file which includes
an enforcement status field. If this field is not set to "enforce", all
BIOS config checks will happen, but the config will not be applied. This
allows us to improve the config normalization filters during a
development period, after which we can set the enforcement status to
enable the config to be written when drift is detected.