### PR TITLE
Add retry to the tink() function and expand option names

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -81,6 +81,7 @@ function tink() {
 		--fail \
 		--header "Content-Type: application/json" \
 		--request "${method}" \
+		--retry 3 \
 		"${tink_host}/${endpoint}"
 }
 

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -76,11 +76,11 @@ function tink() {
 	local method=$1 tink_host=$2 endpoint=$3 post_data=$4
 
 	curl \
-		-f \
 		-vvvvv \
-		-X "${method}" \
-		-H "Content-Type: application/json" \
-		-d "${post_data}" \
+		--data "${post_data}" \
+		--fail \
+		--header "Content-Type: application/json" \
+		--request "${method}" \
 		"${tink_host}/${endpoint}"
 }
 


### PR DESCRIPTION
## Description

Lets add a retry to the tink() function as an attempt to make this more durable.

Also lets expand the options to the long form so they are more human readable.

## Why is this needed

Should lead to more success

Fixes: # ENG-11710

## How Has This Been Tested?
Untested at the moment


## How are existing users impacted? What migration steps/scripts do we need?
No break, only fix :crossed_fingers: 

