### PR TITLE
Set a default value of 'true' for reserved metadata

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -37,7 +37,7 @@ assert_all_args_consumed "$OPTIND" "$@"
 
 declare facility && set_from_metadata facility 'facility' <"$metadata"
 declare class && set_from_metadata class 'class' <"$metadata"
-declare reserved && set_from_metadata reserved 'reserved' <"$metadata"
+declare reserved && set_from_metadata reserved 'reserved' true <"$metadata"
 declare tinkerbell && set_from_metadata tinkerbell 'phone_home_url' <"$metadata"
 declare id && set_from_metadata id 'id' <"$metadata"
 declare preserve_data && set_from_metadata preserve_data 'preserve_data' false <"$metadata"


### PR DESCRIPTION
In case the 'reserved' metadata is missing, default to true. The only
thing that uses this is the BIOS validation on deprov code, and will
prevent that from possibly being run destructively on a reserved server.