### PR TITLE
Fix detection of BIOS drift via diff file

### DIFF
--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -337,7 +337,7 @@ function apply_bios_config() {
 	local vendor=$1
 	local config_file=$2
 
-	if [[ ! -f bios_config_drift.diff || -s bios_config_drift.diff ]]; then
+	if [[ ! -s bios_config_drift.diff ]]; then
 		echo "No BIOS config drift detected, not applying new config"
 		return 0
 	fi


### PR DESCRIPTION
I had the logic of -s backwards previously. The -f wasn't necessary
either.