### PR TITLE
Do not fail deprovisions when SOL causes docker to hang

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -294,9 +294,10 @@ phone_home "${tinkerbell}" '{"instance_id": "'"$id"'"}'
 etimer=$(date +%s)
 echo -e "${BYELLOW}Clean time: $((etimer - stimer))${NC}"
 
-set_autofail_stage "OSIE deprov final stage"
+set_autofail_stage "generating cleanup.sh script"
 cat >/statedir/cleanup.sh <<EOF
 #!/bin/sh
 poweroff
 EOF
 chmod +x /statedir/cleanup.sh
+set_autofail_stage "deprovision completed"


### PR DESCRIPTION
If SOL isn't working properly during deprovision, docker can hang even
though the deprovision script has run to completion. This change sets
the autofail message to "deprovision completed" at the very end of the
deprovision script, so that if docker hangs and is killed by the timeout
watcher, we can detect that the deprovision script completed and cleanup
gracefully instead of failing the deprovision.

Signed-off-by: Scott Garman <sgarman@packet.com>