### PR TITLE
osie: log/report exit code

### DIFF
--- a/apps/osie-installer.sh
+++ b/apps/osie-installer.sh
@@ -195,7 +195,7 @@ other_consoles=$(
 
 [ -z "$syslog_host" ] && syslog_host="$tinkerbell"
 
-container_timeout=1200 # seconds (20 minutes)
+container_timeout=$((20 * 60)) # 20 minutes in seconds
 timeout_cmd="timeout -s SIGKILL $container_timeout"
 if [ "$arch" = "aarch64" ]; then
 	# aarch64 is still using an older alpine, which has different syntax for timeout

--- a/apps/osie-installer.sh
+++ b/apps/osie-installer.sh
@@ -15,9 +15,12 @@ fail() {
 		fi
 	fi
 
-	curl -H 'Content-Type: application/json' \
-		-d '{"type":"failure", "reason":"'"$reason"'"}' \
-		"$phone_home_url"
+	curl \
+		-H 'Content-Type: application/json' \
+		-d @- \
+		"$phone_home_url" <<-EOF
+			{"type":"failure", "reason":"$reason"}
+		EOF
 }
 
 # ensure_time fetches metadata via http and compares the time the server says it

--- a/apps/osie-installer.sh
+++ b/apps/osie-installer.sh
@@ -4,6 +4,9 @@
 
 reason='unknown'
 fail() {
+	code=$?
+	echo "last command returned exit_code=$code" >&2
+
 	if [ "$reason" = "docker exited with an error (osie-installer)" ]; then
 		# If OSIE exited with a non-zero return value, its autofail() trap function
 		# would have reported the failure reason. A failure from docker here is then
@@ -19,7 +22,7 @@ fail() {
 		-H 'Content-Type: application/json' \
 		-d @- \
 		"$phone_home_url" <<-EOF
-			{"type":"failure", "reason":"$reason"}
+			{"type":"failure", "reason":"$reason", "exit_code":"$code"}
 		EOF
 }
 


### PR DESCRIPTION
## Description

Sends exit code to PAPI when an error occurs

## Why is this needed

We've seen deprovisions on machines without SOL configured run to completion successfully only to be marked as failed in PAPI due to a "timeout".
Everything looks fine up until when docker is supposed to exit.
The script definitely does not make it past the `docker run` call and instead errexits and the trap phones home a failure.
I suspect a SIGPIPE while trying to `tee $other_consoles`, but with out the error code its hard to know.

## How Has This Been Tested?

Locally in vm tests.


## How are existing users impacted? What migration steps/scripts do we need?

Better logs.
