### PR TITLE
workflow-helper: Updates to support docker syslog logging

### DIFF
--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -45,13 +45,13 @@ mkdir -p /etc/docker/ /etc/docker/certs.d/ "/etc/docker/certs.d/$docker_registry
 cp ca.pem "/etc/docker/certs.d/$docker_registry/ca.crt"
 
 # configure docker daemon
-cat > /etc/docker/daemon.json <<- EOM
-{
-  "log-driver": "syslog",
-  "log-opts": {
-    "syslog-address": "udp://${syslog_host}:514"
-  }
-}
+cat >/etc/docker/daemon.json <<-EOM
+	{
+	  "log-driver": "syslog",
+	  "log-opts": {
+	    "syslog-address": "udp://${syslog_host}:514"
+	  }
+	}
 EOM
 
 service docker start

--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -10,9 +10,9 @@ registry_username=$(sed -nr 's|.*\bregistry_username=(\S+).*|\1|p' /proc/cmdline
 registry_password=$(sed -nr 's|.*\bregistry_password=(\S+).*|\1|p' /proc/cmdline)
 syslog_host=$(sed -nr 's|.*\bsyslog_host=(\S+).*|\1|p' /proc/cmdline)
 worker_id=$(sed -nr 's|.*\bworker_id=(\S+).*|\1|p' /proc/cmdline)
-id=$(sed -nr 's|.*\binstance_id=(\S+).*|\1|p' /proc/cmdline)
+instance_id=$(sed -nr 's|.*\binstance_id=(\S+).*|\1|p' /proc/cmdline)
 
-tink_worker_image="${docker_registry}/tinkerbell/tink-worker:sha-745c2d09"
+tink_worker_image="${docker_registry}/tinkerbell/tink-worker:sha-5e1f0fd8"
 
 # Create workflow motd
 cat <<'EOF'
@@ -78,7 +78,7 @@ mkdir /worker
 # TODO: remove setting WORKER_ID when we no longer want to support backwards compatibility
 # with the older tink-worker
 docker run --privileged -t --name "tink-worker" \
-	-e "container_uuid=$id" \
+	-e "container_uuid=$instance_id" \
 	-e "WORKER_ID=$worker_id" \
 	-e "ID=$worker_id" \
 	-e "DOCKER_REGISTRY=$docker_registry" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,7 @@ RUN apt-get update -y && \
 ARG PACKET_HARDWARE_COMMIT=68a25da2b6a3d3281838bff6b62639438116d0d1
 ARG PACKET_NETWORKING_COMMIT=2c201b2da0563ca9363f78170663c0baa6054e32
 
-RUN curl https://bootstrap.pypa.io/3.5/get-pip.py | python3 && \
+RUN curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 && \
     pip3 install git+https://github.com/packethost/packet-hardware.git@${PACKET_HARDWARE_COMMIT} && \
     pip3 install git+https://github.com/packethost/packet-networking.git@${PACKET_NETWORKING_COMMIT} && \
     rm -rf ~/.cache/pip*

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --update --upgrade --no-cache bash docker jq libstdc++ python3
 COPY requirements.txt .
 RUN apk add --update --upgrade --no-cache --virtual build-deps alpine-sdk curl linux-headers python3-dev && \
     # Latest version is ok/on purpose
-    curl -sSL https://bootstrap.pypa.io/3.5/get-pip.py -o get-pip.py && \
+    curl -sSL https://bootstrap.pypa.io/pip/3.5/get-pip.py -o get-pip.py && \
     python3 get-pip.py && \
     pip install -r requirements.txt && \
     yes y | python3 -m pip uninstall pip && \


### PR DESCRIPTION
## Description

* Configure docker to log via syslog to syslog_host
* Derive instance id 'id' from cmdline
* Define tink-worker image from var

## Why is this needed

To centralize logging of workflow actions.   boots accepts syslog input and logs it to STDOUT along with the boots specific logs.    This log can in turn be sent off to a centralized logging repository.

Additionally we also make it easier to define the tink-worker image and correct a development artifact around the instance id.

ENG-11778
