### PR TITLE
grub-installer: lets try a different path

### DIFF
--- a/docker/scripts/grub-installer.sh
+++ b/docker/scripts/grub-installer.sh
@@ -128,6 +128,8 @@ install_grub_osie() {
 
 		grub-install --recheck --bootloader-id=GRUB --root-directory="$target" --efi-directory="$target/boot/efi"
 		grubefi=$(find "$target/boot/efi" -name 'grub*.efi' -print -quit)
+		install -Dm755 "$grubefi" "$target/boot/efi/EFI/BOOT/BOOTX64.EFI"
+
 		if [[ -z $grubefi ]]; then
 			echo "error: couldn't find a suitable grub EFI file"
 			exit 1


### PR DESCRIPTION
## Description

This installs to boot/bootx64.efi as well as grub/grubx64.efi which 
seems to result in better UEFI support across different hardware types

## Why is this needed

Seems to resolve some EFI related issues

## How Has This Been Tested?

In production, on the fleet, several varieties

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 