### PR TITLE
wosie.sh: remove ping-based check for OS image source

### DIFF
--- a/docker/scripts/wosie.sh
+++ b/docker/scripts/wosie.sh
@@ -97,11 +97,10 @@ else
 	echo "NOTICE: Custom image url found!"
 	echo "Overriding default image location with custom image_url"
 	image="$image_url"
-
-	ensure_reachable "${image}"
 fi
 echo "Image: $image"
 
+set_autofail_stage "checking OS image url is accessible"
 if ! wget --spider "${image}"; then
 	echo "$0: Image URL unavailable: $image" >&2
 	exit 1


### PR DESCRIPTION
In osie.sh, we replaced the use of ensure_reachable() with the
github_mirror_check() function, to avoid the use of ping, which doesn't
work as a valid test in our k8s facilities. In wosie.sh, we test that
the OS image url is accessible with wget, so ensure_reachable() isn't
needed anymore.

Signed-off-by: Scott Garman <sgarman@packet.com>