### PR TITLE
Add blocksize for specific Intel NVMe drives

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -163,7 +163,7 @@ if [[ $preserve_data == false ]]; then
 				done
 			fi
 
-			nvmemodel=$(nvme id-ctrl "$drive" -o json | jq -r '.mn')
+			nvmemodel=$(nvme id-ctrl "$drive" -o json | jq -r '.mn' | sed -e 's/[[:space:]]*$//')
 			if [[ $nvmemodel == 'INTEL SSDPE2KX040T8' ]]; then
 				# Set specific block size depending on physical BD
 				sectors=$((max_bytes / 4096))

--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -163,8 +163,15 @@ if [[ $preserve_data == false ]]; then
 				done
 			fi
 
-			# flbas 0 uses 512 byte sector sizes
-			sectors=$((max_bytes / 512))
+			nvmemodel=$(nvme id-ctrl "$drive" -o json | jq -r '.mn')
+			if [[ $nvmemodel == 'INTEL SSDPE2KX040T8' ]]; then
+				# Set specific block size depending on physical BD
+				sectors=$((max_bytes / 4096))
+			else
+				# default flbas 0 uses 512 byte sector sizes
+				sectors=$((max_bytes / 512))
+			fi
+
 			echo "Creating a single namespace with $sectors sectors on $drive"
 			nsid=$(nvme create-ns "$drive" --nsze=$sectors --ncap=$sectors --flbas 0 --dps=0 | cut -d : -f 3)
 			ctrl=$(nvme id-ctrl "$drive" -o json | jq '.cntlid')


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

This fixes the namespare error while deprovisioning machines with specific Intel NVMe drives

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
Testing via custom userdata / custom OSIE method 


## How are existing users impacted? What migration steps/scripts do we need?
NA


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
