### PR TITLE
Do not fail when SOL causes docker to return error

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -301,9 +301,10 @@ phone_home "${tinkerbell}" '{"instance_id": "'"$id"'"}'
 etimer=$(date +%s)
 echo -e "${BYELLOW}Clean time: $((etimer - stimer))${NC}"
 
-set_autofail_stage "OSIE deprov final stage"
+set_autofail_stage "generating cleanup.sh script"
 cat >/statedir/cleanup.sh <<EOF
 #!/bin/sh
 poweroff
 EOF
 chmod +x /statedir/cleanup.sh
+set_autofail_stage "completed"

--- a/docker/scripts/frosie.sh
+++ b/docker/scripts/frosie.sh
@@ -382,4 +382,4 @@ cat >/statedir/cleanup.sh <<EOF
 reboot
 EOF
 chmod +x /statedir/cleanup.sh
-set_autofail_stage "frOSIE completed, exiting to osie-installer"
+set_autofail_stage "completed"

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -621,3 +621,4 @@ EOF
 fi
 
 chmod +x /statedir/cleanup.sh
+set_autofail_stage "completed"

--- a/docker/scripts/vosie.sh
+++ b/docker/scripts/vosie.sh
@@ -554,3 +554,4 @@ cat >/statedir/cleanup.sh <<EOF
 reboot
 EOF
 chmod +x /statedir/cleanup.sh
+set_autofail_stage "completed"

--- a/docker/scripts/wosie.sh
+++ b/docker/scripts/wosie.sh
@@ -191,4 +191,4 @@ cat >/statedir/cleanup.sh <<EOF
 reboot
 EOF
 chmod +x /statedir/cleanup.sh
-set_autofail_stage "wOSIE completed, exiting to osie-installer"
+set_autofail_stage "completed"


### PR DESCRIPTION
## Description

Don't blindly fail just because docker returned an error.

## Why is this needed

Defensive coding to protect against effectively fake failures for production EM use, mostly deprovisions but also some provisions.

## How Has This Been Tested?

In production.
