### PR TITLE
Always pull the latest tink-worker image

### DIFF
--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -12,7 +12,7 @@ syslog_host=$(sed -nr 's|.*\bsyslog_host=(\S+).*|\1|p' /proc/cmdline)
 worker_id=$(sed -nr 's|.*\bworker_id=(\S+).*|\1|p' /proc/cmdline)
 instance_id=$(sed -nr 's|.*\binstance_id=(\S+).*|\1|p' /proc/cmdline)
 
-tink_worker_image="${docker_registry}/tinkerbell/tink-worker:sha-5e1f0fd8"
+tink_worker_image="${docker_registry}/tinkerbell/tink-worker:latest"
 
 # Create workflow motd
 cat <<'EOF'


### PR DESCRIPTION

## Description

Change tink-worker image to the latest tag.

## Why is this needed

Currently if somebody will run the latest sandbox then they will not be able to pull tink-worker image.
As the comments indicates: [link](https://github.com/tinkerbell/sandbox/blob/master/setup.sh#L390)

> osie looks for tink-worker:latest, so we have to play with it a bit

The above sentence is false righ now, OSIE points to the specific sha.

Fixes: #

## How Has This Been Tested?
Local setup.

## How are existing users impacted? What migration steps/scripts do we need?

Won't be able to download tink-worker image inside OSIE.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
