### PR TITLE
Temporarily disable bios validation

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -70,11 +70,12 @@ if [[ $arch == x86_64 ]] && [[ $reserved != "true" ]]; then
 	bios_version=$(detect_bios_version "${bios_vendor}")
 	echo "BIOS detected: ${bios_vendor} ${bios_version}"
 
-	set_autofail_stage "downloading BIOS configs"
-	download_bios_configs
+	# TEMPORARILY DISABLED:
+	#set_autofail_stage "downloading BIOS configs"
+	#download_bios_configs
 
-	set_autofail_stage "validating BIOS config"
-	validate_bios_config "${class}" "${bios_vendor}"
+	#set_autofail_stage "validating BIOS config"
+	#validate_bios_config "${class}" "${bios_vendor}"
 fi
 
 # Storage detection

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -1010,7 +1010,7 @@ function github_mirror_check() {
 	echo -e "${YELLOW}###### Checking the health of github-mirror.packet.net...${NC}"
 
 	# Clone the repo, and checkout an LFS branch.
-	local timeout=20 # seconds
+	local timeout=10 # seconds
 	local lfs_testing_uri="https://github-mirror.packet.net/packethost/lfs-testing.git"
 	local lfs_testing_branch="remotes/origin/images-tiny"
 	if ! timeout --preserve-status $timeout git clone -q $lfs_testing_uri; then


### PR DESCRIPTION
Disabling this temporarily while we address some infrastructure issues where the BIOS configs are hosted from.