### PR TITLE
Re-enable bios-configs tarball download, use S3 bucket

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -70,12 +70,11 @@ if [[ $arch == x86_64 ]] && [[ $reserved != "true" ]]; then
 	bios_version=$(detect_bios_version "${bios_vendor}")
 	echo "BIOS detected: ${bios_vendor} ${bios_version}"
 
-	# TEMPORARILY DISABLED:
-	#set_autofail_stage "downloading BIOS configs"
-	#download_bios_configs
+	set_autofail_stage "downloading BIOS configs"
+	download_bios_configs
 
-	#set_autofail_stage "validating BIOS config"
-	#validate_bios_config "${class}" "${bios_vendor}"
+	set_autofail_stage "validating BIOS config"
+	validate_bios_config "${class}" "${bios_vendor}"
 fi
 
 # Storage detection

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -158,11 +158,11 @@ function download_bios_configs() {
 	curl \
 		--fail \
 		--retry 3 \
-		https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz --output bios-configs-latest.tar.gz
+		https://bios-configs.platformequinix.net/bios-configs-latest.tar.gz --output bios-configs-latest.tar.gz
 	curl \
 		--fail \
 		--retry 3 \
-		https://github-mirror.packet.net/downloads/bios-configs-latest.tar.gz.sha256 --output bios-configs-latest.tar.gz.sha256
+		https://bios-configs.platformequinix.net/bios-configs-latest.tar.gz.sha256 --output bios-configs-latest.tar.gz.sha256
 
 	echo "Verifying BIOS configurations tarball"
 	sha256sum --check bios-configs-latest.tar.gz.sha256


### PR DESCRIPTION
The new bios-configs.platformequinix.net hostname points to our IPN
anycast address, which then caches tarballs stored in our S3 bucket
upstream. This will decouple OSIE deprovisions from having a hard
dependency on github-mirror.

Signed-off-by: Scott Garman <sgarman@equinix.com>
