### PR TITLE
packet-networking: update to new Ubuntu ENI ordering

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /tmp/osie/
 
 ARG PACKET_HARDWARE_COMMIT=68a25da2b6a3d3281838bff6b62639438116d0d1
-ARG PACKET_NETWORKING_COMMIT=2c201b2da0563ca9363f78170663c0baa6054e32
+ARG PACKET_NETWORKING_COMMIT=06061801efaf34caa8d8b1ae5973c15e5a23659d
 
 RUN curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 && \
     pip3 install git+https://github.com/packethost/packet-hardware.git@${PACKET_HARDWARE_COMMIT} && \


### PR DESCRIPTION
## Description

This reorders the /etc/network/interfaces file we generate for Ubunutu so that the ifaces are
above the bond in the ordering, which allows for a successful `systemctl restart networking`
https://github.com/packethost/packet-networking/pull/35

## Why is this needed

Much better experience

Fixes: ENG-14736

## How Has This Been Tested?

Looks good on Ubuntu 16/18/20 via custom OSIE provisions

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 
