### PR TITLE
debian9: stop forcing biosdevname and netifnames

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/* /tmp/osie/
 
 ARG PACKET_HARDWARE_COMMIT=68a25da2b6a3d3281838bff6b62639438116d0d1
-ARG PACKET_NETWORKING_COMMIT=06061801efaf34caa8d8b1ae5973c15e5a23659d
+ARG PACKET_NETWORKING_COMMIT=3bb688df0861414dc4146a0c229c20816c4a5b6a
 
 RUN curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 && \
     pip3 install git+https://github.com/packethost/packet-hardware.git@${PACKET_HARDWARE_COMMIT} && \

--- a/grub/debian_9-default-grub.template
+++ b/grub/debian_9-default-grub.template
@@ -46,7 +46,7 @@ menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
 		else
 		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
 		fi
-		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1 $vt_handoff
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
 		initrd /boot/initrd
 }
 

--- a/grub/debian_9-default-grub.template.default
+++ b/grub/debian_9-default-grub.template.default
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8 biosdevname=0 net.ifnames=1'
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
 GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'


### PR DESCRIPTION
## Description

Lets stop forcing biosdevname=0 net.ifnames=1 and use udev rules to control NIC names

## Why is this needed

For networking to work properly

Fixes: #

## How Has This Been Tested?

Testing in progress

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 

