### PR TITLE
ENG-15046 - add new metadata IP to list of metdata_urls

### DIFF
--- a/docker/scripts/frosie.sh
+++ b/docker/scripts/frosie.sh
@@ -316,7 +316,7 @@ if [ -f "$target/usr/local/etc/cloud/cloud.cfg" ]; then
 		  Ec2:
 		    timeout: 60
 		    max_wait: 120
-		    metadata_urls: [ 'http://metadata.packet.net', '147.75.207.1' ]
+		    metadata_urls: [ 'http://metadata.packet.net', 'http://147.75.207.1:80' ]
 		    dsmode: net
 		cloud_init_modules:
 		 - migrator

--- a/docker/scripts/frosie.sh
+++ b/docker/scripts/frosie.sh
@@ -316,7 +316,7 @@ if [ -f "$target/usr/local/etc/cloud/cloud.cfg" ]; then
 		  Ec2:
 		    timeout: 60
 		    max_wait: 120
-		    metadata_urls: [ 'https://metadata.packet.net' ]
+		    metadata_urls: [ 'http://metadata.packet.net', '147.75.207.1' ]
 		    dsmode: net
 		cloud_init_modules:
 		 - migrator

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -357,7 +357,7 @@ EOF
 			  Ec2:
 			    timeout: 60
 			    max_wait: 120
-			    metadata_urls: [ 'https://metadata.packet.net' ]
+			    metadata_urls: [ 'http://metadata.packet.net', '147.75.207.1' ]
 			    dsmode: net
 			disable_root: 0
 			package_reboot_if_required: false

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -357,7 +357,7 @@ EOF
 			  Ec2:
 			    timeout: 60
 			    max_wait: 120
-			    metadata_urls: [ 'http://metadata.packet.net', '147.75.207.1' ]
+			    metadata_urls: [ 'http://metadata.packet.net', 'http://147.75.207.1:80' ]
 			    dsmode: net
 			disable_root: 0
 			package_reboot_if_required: false

--- a/docker/scripts/vosie.sh
+++ b/docker/scripts/vosie.sh
@@ -342,7 +342,7 @@ if [ -f $target/etc/cloud/cloud.cfg ]; then
 		  Ec2:
 		    timeout: 60
 		    max_wait: 120
-		    metadata_urls: [ 'https://metadata.packet.net' ]
+		    metadata_urls: [ 'http://metadata.packet.net', '147.75.207.1' ]
 		    dsmode: net
 		cloud_init_modules:
 		 - DataSourceEc2

--- a/docker/scripts/vosie.sh
+++ b/docker/scripts/vosie.sh
@@ -342,7 +342,7 @@ if [ -f $target/etc/cloud/cloud.cfg ]; then
 		  Ec2:
 		    timeout: 60
 		    max_wait: 120
-		    metadata_urls: [ 'http://metadata.packet.net', '147.75.207.1' ]
+		    metadata_urls: [ 'http://metadata.packet.net', 'http://147.75.207.1:80' ]
 		    dsmode: net
 		cloud_init_modules:
 		 - DataSourceEc2


### PR DESCRIPTION
## Description

We frequently run into an issue where the `metadata.packet.net` cannot be resolved during provisioning (we believe this a race condition with the network coming up). When this happens we see this in the cloud-init logs:

```
2021-05-12 15:59:07,606 - util.py[DEBUG]: Resolving URL: https://metadata.packet.net took 48.667 seconds
2021-05-12 15:59:07,606 - DataSourceEc2.py[DEBUG]: Removed the following from metadata urls: ['https://metadata.packet.net']
2021-05-12 15:59:07,606 - DataSourceEc2.py[WARNING]: Empty metadata url list! using default list
```
The default list is the Amazon EC2 url (`169.254.169.254`) which will never work for us. 

This PR adds a new IP that talks directly to kant so if the metadata.packet.net url is removed the IP will remain on the list believe this should work instead.

I've also switched this to `http` from `https` because this shouldn't need to go over https and the new IP will not. 

## Why is this needed

Should hopefully fix the above where the metadata.packet.net url is removed so the ssh authorized keys are not added to the server during provisioning. 

## How Has This Been Tested?
I've tested this new IP in la4 and it works as expected:

```
curl -s 147.75.207.1/metadata |jq
{
  "id": 
...
```

This is setup with an nginx pod to only allow traffic for the specific paths set originally in the metadata.packet.net ingress. 

I have not tested this specific osie change. 

## How are existing users impacted? What migration steps/scripts do we need?

This fixes a bug, it should not introduce any regressions. 


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
