### PR TITLE
Change bootloader-id to work correctly after grub boothole v2 updates

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache --no-progress --update --upgrade \
         libarchive-tools \
         make \
         musl-dev \
+        ncurses \
         ovmf \
         pigz \
         py3-pip \
@@ -69,3 +70,4 @@ RUN curl -L https://github.com/git-lfs/git-lfs/releases/download/v2.5.1/git-lfs-
     git-lfs install
 
 COPY tls/ /tls/
+ENV TERM=xterm-256color

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -342,10 +342,14 @@ do_test() {
 	'x86_64') console=ttyS1,115200 ;;
 	esac
 
-	test_provision
+	color=33
+	colorize $color "== Running Provision Test =="
+	test_provision |& stdbuf -i 0 sed "s/^/$(colorize $color 'test_provision│')/"
 	rm -f uploads/*
 
-	test_deprovision
+	color=34
+	colorize $color "== Running Deprovision Test =="
+	test_deprovision |& stdbuf -i 0 sed "s/^/$(colorize $color 'test_deprovision│')/"
 	rm -f uploads/*
 }
 
@@ -366,6 +370,12 @@ configure_nics() {
 			/bin/true/bin/true)
 		EOF
 	)
+}
+
+function colorize() {
+	local color=$1
+	shift
+	printf "$(tput sgr0)$(tput setaf "$color")%s$(tput sgr0)" "$*"
 }
 
 test_provision() {

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -354,12 +354,6 @@ do_test() {
 	diff -u <(jq -cS . <<<'{"type":"provisioning.109"}') <(jq -cS . "$(grep -rl 'provisioning.109' uploads)")
 }
 
-do_network_test() {
-	cd "$scriptdir"
-	pip3 install ../docker/scripts/packet-networking
-	./test-network.sh
-}
-
 get_subnet() {
 	# convert subnets in use into grep -E pattern
 	pattern=$(ip -4 addr | awk '/inet 172/ {print $2}' | sort -h | sed 's|172.\([0-9]\+\).*|\1|' | tr '\n' '|' | sed -e 's/^/^(/' -e 's/|$/)/')
@@ -422,4 +416,4 @@ if [[ $cmd == tests ]]; then
 	exit
 fi
 
-"do_$cmd" "$@"
+do_test "$@"

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -75,7 +75,7 @@ gen_metadata() {
 		cprcmd=(jq -S '.filesystems += [{"mount":{"create":{"options": ["32", "-n", "EFI"]},"device":"/dev/sda1","format":"vfat","point":"/boot/efi"}}]')
 	fi
 
-	cat <<-EOF
+	cat <<-EOF | sed '/\bsd[a-z]\+[0-9]*\b/ s|\bs\(d[a-z]\+[0-9]*\)\b|v\1|' | jq -S . | tee metadata
 		{
 		  "class": "$class",
 		  "facility": "$facility",
@@ -321,10 +321,7 @@ do_test() {
 	fi
 
 	# rename disk from scsi names to virtio names, e.g. sda1 -> vda1
-	gen_metadata "$class" "$slug" "$tag" <"$scriptdir/cpr/$class.cpr.json" |
-		sed '/\bsd[a-z]\+[0-9]*\b/ s|\bs\(d[a-z]\+[0-9]*\)\b|v\1|' |
-		jq -S . |
-		tee metadata
+	gen_metadata "$class" "$slug" "$tag" <"$scriptdir/cpr/$class.cpr.json"
 
 	start_dhcp \
 		--dhcp-host="${macs[0]},$pubip4" \

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -286,12 +286,15 @@ run_vm() {
 	# shellcheck disable=SC2068
 	"qemu-system-$arch" \
 		"$@" \
+		-monitor unix:monitor.sock,server=on,wait=off \
+		-nodefaults \
 		-nographic \
-		-machine $machine,accel=kvm:tcg -cpu $cpu -smp 2 \
+		-serial pty \
+		-serial stdio \
+		-machine $machine,accel=kvm:tcg -cpu $cpu -smp 2 -m 8192 \
 		-drive if=virtio,file="$disk",format=raw \
 		-object rng-random,filename=/dev/urandom,id=rng0 \
 		-device virtio-rng-pci,rng=rng0 \
-		-m 8192 \
 		${bios[@]} \
 		-netdev tap,id=net0,script="$script0",downscript=/bin/true -device "virtio-net,netdev=net0,mac=$mac0" \
 		-netdev tap,id=net1,script="$script1",downscript=/bin/true -device "virtio-net,netdev=net1,mac=$mac1" \
@@ -341,7 +344,7 @@ do_test() {
 
 	case $arch in
 	'aarch64') console=ttyAMA0,115200 ;;
-	'x86_64') console=ttyS0,115200 ;;
+	'x86_64') console=ttyS1,115200 ;;
 	esac
 	cmdline=''
 	cmdline="$cmdline console=$console"

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -176,29 +176,33 @@ start_web() {
 
 	cat >Caddyfile <<-EOF
 		install.$facility.packet.net:80 {
-		    tls off
 		    browse
+		    tls off
+
 		    proxy /misc/osie/current/repo-$arch install.ewr1.packet.net/alpine/$repo_dest/
 		    rewrite /misc/osie/current {
-			regexp (.*)
-			to {1}
+		        regexp (.*)
+		        to {1}
 		    }
 		    proxy /repo-$arch/ install.ewr1.packet.net/alpine/$repo_dest/ {
-			without /repo-$arch/
+		        without /repo-$arch/
 		    }
 		    proxy /misc/osie install.ewr1.packet.net
 		    proxy /alpine/ install.ewr1.packet.net
 		}
+
 		tinkerbell.$facility.packet.net:80 {
 		    tls off
 		    upload / {
-			to "uploads"
-			random_suffix_len 5
-			yes_without_tls
+		        to "uploads"
+		        random_suffix_len 5
+		        yes_without_tls
 		    }
 		}
+
 		metadata.packet.net:80 {
 		}
+
 		metadata.packet.net:443 {
 		    tls server.pem server-key.pem
 		}

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -243,11 +243,11 @@ teardown() {
 }
 
 run_vm() {
-	local bios=() cmdline='' cpu='' machine='' console='' nic=''
+	local bios=() cmdline='' cpu='' machine='' console=''
 
 	case $arch in
-	'aarch64') console=ttyAMA0,115200 nic=virtio-net ;;
-	'x86_64') console=ttyS0,115200 nic=e1000 ;;
+	'aarch64') console=ttyAMA0,115200 ;;
+	'x86_64') console=ttyS0,115200 ;;
 	esac
 	case $(uname -m)-$arch in
 	'aarch64-aarch64') machine=virt cpu=host ;;
@@ -303,10 +303,10 @@ run_vm() {
 		-device virtio-rng-pci,rng=rng0 \
 		-m 8192 \
 		${bios[@]} \
-		-netdev tap,id=net0,script="$script0",downscript=/bin/true -device "$nic,netdev=net0,mac=$mac0" \
-		-netdev tap,id=net1,script="$script1",downscript=/bin/true -device "$nic,netdev=net1,mac=$mac1" \
-		-netdev tap,id=net2,script="$script2",downscript=/bin/true -device "$nic,netdev=net2,mac=$mac2" \
-		-netdev tap,id=net3,script="$script3",downscript=/bin/true -device "$nic,netdev=net3,mac=$mac3" \
+		-netdev tap,id=net0,script="$script0",downscript=/bin/true -device "virtio-net,netdev=net0,mac=$mac0" \
+		-netdev tap,id=net1,script="$script1",downscript=/bin/true -device "virtio-net,netdev=net1,mac=$mac1" \
+		-netdev tap,id=net2,script="$script2",downscript=/bin/true -device "virtio-net,netdev=net2,mac=$mac2" \
+		-netdev tap,id=net3,script="$script3",downscript=/bin/true -device "virtio-net,netdev=net3,mac=$mac3" \
 		;
 }
 

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o nounset -o pipefail -o xtrace
 

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -348,6 +348,10 @@ do_test() {
 	esac
 
 	test_provision
+	rm -f uploads/*
+
+	test_deprovision
+	rm -f uploads/*
 }
 
 test_provision() {
@@ -369,6 +373,34 @@ test_provision() {
 	#shellcheck disable=SC2089
 	want='{"type":"provisioning.109"}'
 	diff -u <(jq -cS . <<<"$want") <(jq -cS . <<<"$got")
+}
+
+test_deprovision() {
+	local cmdline=''
+	cmdline="$cmdline console=$console"
+	cmdline="$cmdline facility=$facility"
+	cmdline="$cmdline ip=dhcp"
+	cmdline="$cmdline modloop=http://install.$facility.packet.net/misc/osie/current/$modloop"
+	cmdline="$cmdline modules=loop,squashfs,sd-mod,usb-storage"
+	cmdline="$cmdline rw"
+	cmdline="$cmdline tinkerbell=http://tinkerbell.$facility.packet.net"
+	cmdline="$cmdline packet_action=install packet_state=deprovisioning packet_bootdev_mac=${macs[0]} slug=deprovision"
+	run_vm -kernel "$kernel" -initrd "$initramfs" -append "$cmdline"
+
+	# check for deprovisioning finished message
+	eventid=deprovisioning.306.02
+	grep -qr "$eventid" uploads
+	got=$(grep -hr "$eventid" uploads)
+	#shellcheck disable=SC2089
+	want='{"type":"deprovisioning.306.02","body":"Deprovision finished, rebooting server","private":true}'
+	diff -u <(jq -cS . <<<"$want") <(jq -cS . <<<"$got")
+
+	echo "Checking if disks were wiped"
+	if fdisk -l "$disk" 2>/dev/null | grep Disklabel >/dev/null; then
+		echo "disks were not wiped correctly!"
+		fdisk -l "$disk"
+		exit 2
+	fi
 }
 
 get_subnet() {

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -399,6 +399,7 @@ test | tests)
 	check_required_arg_file "$kernel" 'kernel' '-k'
 	check_required_arg_file "$modloop" 'modloop' '-m'
 	;;
+*) echo "unknown command $cmd" >&2 && exit 1 ;;
 esac
 
 if [[ $cmd == tests ]]; then

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -177,6 +177,7 @@ start_web() {
 	cat >Caddyfile <<-EOF
 		install.$facility.packet.net:80 {
 		    browse
+		    log stderr
 		    tls off
 
 		    proxy /misc/osie/current/repo-$arch install.ewr1.packet.net/alpine/$repo_dest/
@@ -192,6 +193,7 @@ start_web() {
 		}
 
 		tinkerbell.$facility.packet.net:80 {
+		    log stderr
 		    tls off
 		    upload / {
 		        to "uploads"
@@ -201,15 +203,17 @@ start_web() {
 		}
 
 		metadata.packet.net:80 {
+		    log stderr
 		}
 
 		metadata.packet.net:443 {
+		    log stderr
 		    tls server.pem server-key.pem
 		}
 	EOF
 
 	mkdir uploads
-	proxy -quiet &
+	proxy &>proxy.log &
 }
 
 stop_web() {

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -346,7 +346,12 @@ do_test() {
 	'aarch64') console=ttyAMA0,115200 ;;
 	'x86_64') console=ttyS1,115200 ;;
 	esac
-	cmdline=''
+
+	test_provision
+}
+
+test_provision() {
+	local cmdline=''
 	cmdline="$cmdline console=$console"
 	cmdline="$cmdline facility=$facility"
 	cmdline="$cmdline ip=dhcp"
@@ -355,10 +360,15 @@ do_test() {
 	cmdline="$cmdline rw"
 	cmdline="$cmdline tinkerbell=http://tinkerbell.$facility.packet.net"
 	cmdline="$cmdline packet_action=install packet_bootdev_mac=${macs[0]} slug=$slug:$tag pwhash=$(echo 5up | mkpasswd)"
-
 	run_vm -kernel "$kernel" -initrd "$initramfs" -append "$cmdline"
-	grep -r 'provisioning.109' uploads
-	diff -u <(jq -cS . <<<'{"type":"provisioning.109"}') <(jq -cS . "$(grep -rl 'provisioning.109' uploads)")
+
+	# check for provision success code
+	eventid=provisioning.109
+	grep -qr "$eventid" uploads
+	got=$(grep -hr "$eventid" uploads)
+	#shellcheck disable=SC2089
+	want='{"type":"provisioning.109"}'
+	diff -u <(jq -cS . <<<"$want") <(jq -cS . <<<"$got")
 }
 
 get_subnet() {

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -275,13 +275,6 @@ run_vm() {
 
 	# scripts matches layout in $macs
 	local scripts=("$scriptdir/ifup.sh" "$scriptdir/ifup.sh" /bin/true /bin/true)
-	local ndxs
-	# shellcheck disable=SC2207
-	ndxs=($(shuf -e 0 1 2 3))
-	local script0=${scripts[${ndxs[0]}]} mac0=${macs[${ndxs[0]}]}
-	local script1=${scripts[${ndxs[1]}]} mac1=${macs[${ndxs[1]}]}
-	local script2=${scripts[${ndxs[2]}]} mac2=${macs[${ndxs[2]}]}
-	local script3=${scripts[${ndxs[3]}]} mac3=${macs[${ndxs[3]}]}
 
 	# shellcheck disable=SC2068
 	"qemu-system-$arch" \
@@ -296,10 +289,10 @@ run_vm() {
 		-object rng-random,filename=/dev/urandom,id=rng0 \
 		-device virtio-rng-pci,rng=rng0 \
 		${bios[@]} \
-		-netdev tap,id=net0,script="$script0",downscript=/bin/true -device "virtio-net,netdev=net0,mac=$mac0" \
-		-netdev tap,id=net1,script="$script1",downscript=/bin/true -device "virtio-net,netdev=net1,mac=$mac1" \
-		-netdev tap,id=net2,script="$script2",downscript=/bin/true -device "virtio-net,netdev=net2,mac=$mac2" \
-		-netdev tap,id=net3,script="$script3",downscript=/bin/true -device "virtio-net,netdev=net3,mac=$mac3" \
+		-netdev tap,id=net0,script="${scripts[0]}",downscript=/bin/true -device "virtio-net,netdev=net0,mac=${macs[0]}" \
+		-netdev tap,id=net1,script="${scripts[1]}",downscript=/bin/true -device "virtio-net,netdev=net1,mac=${macs[1]}" \
+		-netdev tap,id=net2,script="${scripts[2]}",downscript=/bin/true -device "virtio-net,netdev=net2,mac=${macs[2]}" \
+		-netdev tap,id=net3,script="${scripts[3]}",downscript=/bin/true -device "virtio-net,netdev=net3,mac=${macs[3]}" \
 		;
 }
 
@@ -321,6 +314,8 @@ do_test() {
 	if [[ -z $tag ]] || [[ $OS == "$tag" ]]; then
 		tag=$slug-$class
 	fi
+
+	configure_nics
 
 	# rename disk from scsi names to virtio names, e.g. sda1 -> vda1
 	gen_metadata "$class" "$slug" "$tag" <"$scriptdir/cpr/$class.cpr.json"
@@ -352,6 +347,25 @@ do_test() {
 
 	test_deprovision
 	rm -f uploads/*
+}
+
+configure_nics() {
+	# macs[0] == dhcpmac
+	mapfile -t macs < <(
+		shuf <<-EOF
+			52:54:00:BA:DD:00
+			52:54:00:BA:DD:01
+			52:54:00:BA:DD:02
+			52:54:00:BA:DD:03
+		EOF
+	)
+	mapfile -t scripts < <(
+		shuf <<-EOF
+			$scriptdir/ifup.sh
+			$scriptdir/ifup.sh
+			/bin/true/bin/true)
+		EOF
+	)
 }
 
 test_provision() {
@@ -412,15 +426,6 @@ get_subnet() {
 n=$RANDOM
 facility=test$n
 disk=/tmp/test$n.img
-# shellcheck disable=SC2207
-macs=($(
-	shuf <<-EOF
-		52:54:00:BA:DD:00
-		52:54:00:BA:DD:01
-		52:54:00:BA:DD:02
-		52:54:00:BA:DD:03
-	EOF
-)) # macs[0] == dhcpmac
 subnet=$(get_subnet)
 pubip4=$subnet.2
 

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -62,10 +62,9 @@ gen_metadata() {
 	local cprcmd hardware_id id
 	id=$(uuidgen)
 	hardware_id=$(uuidgen)
-	local plan=$1
-	local class=$2
-	local slug=$3
-	local tag=$4
+	local class=$1
+	local slug=$2
+	local tag=$3
 	local distro=${slug%%_*}
 	local version=${slug#*_}
 	version=${version//_/.}
@@ -140,7 +139,6 @@ gen_metadata() {
 		"image_tag": "$tag"
 	},
 	"phone_home_url": "http://tinkerbell.$facility.packet.net",
-	"plan": "$plan",
 	"preserve_data": false,
 	"storage": $("${cprcmd[@]}"),
 	"wipe_disks": true
@@ -304,10 +302,8 @@ do_test() {
 	start_log_rx
 
 	class=t1.small.x86
-	plan=baremetal_0
 	if [ "$arch" = 'aarch64' ]; then
 		class=c1.large.arm
-		plan=baremetal_2a
 	fi
 
 	slug=${OS%:*}
@@ -317,7 +313,7 @@ do_test() {
 	fi
 
 	# rename disk from scsi names to virtio names, e.g. sda1 -> vda1
-	gen_metadata "$plan" "$class" "$slug" "$tag" <"$scriptdir/cpr/$class.cpr.json" |
+	gen_metadata "$class" "$slug" "$tag" <"$scriptdir/cpr/$class.cpr.json" |
 		sed '/\bsd[a-z]\+[0-9]*\b/ s|\bs\(d[a-z]\+[0-9]*\)\b|v\1|' |
 		jq -S . |
 		tee metadata

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -269,8 +269,7 @@ run_vm() {
 				-drive "if=pflash,format=raw,file=$disk.vars"
 			)
 		else
-			# shellcheck disable=SC2178
-			bios=''
+			bios=()
 		fi
 	fi
 

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -75,75 +75,75 @@ gen_metadata() {
 		cprcmd=(jq -S '.filesystems += [{"mount":{"create":{"options": ["32", "-n", "EFI"]},"device":"/dev/sda1","format":"vfat","point":"/boot/efi"}}]')
 	fi
 
-	cat <<EOF
-{
-	"class": "$class",
-	"facility": "$facility",
-	"hardware_id": "$hardware_id",
-	"hostname": "dut",
-	"id": "$id",
-	"network": {
-		"addresses": [
-			{
-				"address": "$pubip4",
-				"address_family": 4,
-				"cidr": 31,
-				"gateway": "$subnet.1",
-				"management": true,
-				"netmask": "255.255.255.254",
-				"network": "$subnet.3",
-				"public": true
-			},
-			{
-				"address": "2604:1380:2:4200::5",
-				"address_family": 6,
-				"cidr": 127,
-				"gateway": "2604:1380:2:4200::4",
-				"management": true,
-				"netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe",
-				"network": "2604:1380:2:4200::4",
-				"public": true
-			},
-			{
-				"address": "10.0.0.2",
-				"address_family": 4,
-				"cidr": 31,
-				"gateway": "10.0.0.1",
-				"management": true,
-				"netmask": "255.255.255.254",
-				"network": "10.0.0.1",
-				"public": false
-			}
-		],
-		"bonding": {
-			"mode": 5
-		},
-		"interfaces": [
-			{
-				"mac": "${macs[0]}",
-				"name": "dummy0"
-			},
-			{
-				"mac": "${macs[1]}",
-				"name": "dummy1"
-			}
-		]
-	},
-	"operating_system": {
-		"slug": "$slug",
-		"distro": "$distro",
-		"version": "$version",
-		"license_activation": {
-		"state": "unlicensed"
-		},
-		"image_tag": "$tag"
-	},
-	"phone_home_url": "http://tinkerbell.$facility.packet.net",
-	"preserve_data": false,
-	"storage": $("${cprcmd[@]}"),
-	"wipe_disks": true
-}
-EOF
+	cat <<-EOF
+		{
+		  "class": "$class",
+		  "facility": "$facility",
+		  "hardware_id": "$hardware_id",
+		  "hostname": "dut",
+		  "id": "$id",
+		  "network": {
+		    "addresses": [
+		      {
+		        "address": "$pubip4",
+		        "address_family": 4,
+		        "cidr": 31,
+		        "gateway": "$subnet.1",
+		        "management": true,
+		        "netmask": "255.255.255.254",
+		        "network": "$subnet.3",
+		        "public": true
+		      },
+		      {
+		        "address": "2604:1380:2:4200::5",
+		        "address_family": 6,
+		        "cidr": 127,
+		        "gateway": "2604:1380:2:4200::4",
+		        "management": true,
+		        "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe",
+		        "network": "2604:1380:2:4200::4",
+		        "public": true
+		      },
+		      {
+		        "address": "10.0.0.2",
+		        "address_family": 4,
+		        "cidr": 31,
+		        "gateway": "10.0.0.1",
+		        "management": true,
+		        "netmask": "255.255.255.254",
+		        "network": "10.0.0.1",
+		        "public": false
+		      }
+		    ],
+		    "bonding": {
+		      "mode": 5
+		    },
+		    "interfaces": [
+		      {
+		        "mac": "${macs[0]}",
+		        "name": "dummy0"
+		      },
+		      {
+		        "mac": "${macs[1]}",
+		        "name": "dummy1"
+		      }
+		    ]
+		  },
+		  "operating_system": {
+		    "distro": "$distro",
+		    "image_tag": "$tag",
+		    "license_activation": {
+		      "state": "unlicensed"
+		    },
+		    "slug": "$slug",
+		    "version": "$version"
+		  },
+		  "phone_home_url": "http://tinkerbell.$facility.packet.net",
+		  "preserve_data": false,
+		  "storage": $("${cprcmd[@]}"),
+		  "wipe_disks": true
+		}
+	EOF
 }
 
 do_symlink_ro_rw() {

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -474,16 +474,6 @@ function is_uefi() {
 	[[ -d /sys/firmware/efi ]]
 }
 
-efi_device() {
-	local efi_path="$1"
-	[ -n "$efi_path" ] && shift || efi_path="/boot/efi"
-	findmnt -n --target "$efi_path" "$@"
-}
-
-find_uuid_boot_id() {
-	efibootmgr -v | grep "$1" | sed 's/^Boot\([0-9a-f]\{4\}\).*/\1/gI;t;d'
-}
-
 # syntax: name key
 # expects metadata in stdin
 # safely sets $name=$metadata[$key]
@@ -1071,12 +1061,4 @@ ip_choose_if() {
 	for x in /sys/class/net/eth*; do
 		[ -e "$x" ] && echo "${x##*/}" && return
 	done
-}
-
-add_post_install_service() {
-	local target="$1"
-	install -Dm700 target-files/bin/packet-post-install.sh "$target/bin/packet-post-install.sh"
-
-	cp -v target-files/services/packet-post-install.service "$target/etc/systemd/system/packet-post-install.service"
-	ln -s /etc/systemd/system/packet-post-install.service "$target/etc/systemd/system/multi-user.target.wants/packet-post-install.service"
 }

--- a/docker/scripts/grub-installer.sh
+++ b/docker/scripts/grub-installer.sh
@@ -2,10 +2,11 @@
 
 # shellcheck disable=SC1091
 source functions.sh && init
+set -u
 
 USAGE="Usage: $0 -t /mnt/target -C /path/to/cprout.json
 Required Arguments:
-	-p plan      Server plan (ex: t1.small.x86)
+	-p class     Server class (ex: t1.small.x86)
 	-t target    Target mount point to write configs to
 	-C path      Path to file containing cpr.sh output json
 	-D path      Path to grub.default template
@@ -19,7 +20,7 @@ Description: This script will configure grub for the target distro
 "
 while getopts "p:t:C:D:T:hv" OPTION; do
 	case $OPTION in
-	p) plan=$OPTARG ;;
+	p) class=$OPTARG ;;
 	t) target="$OPTARG" ;;
 	C) cprout=$OPTARG ;;
 	D) default_path=$OPTARG ;;
@@ -70,89 +71,135 @@ echo "#### Detected OS on mounted target $target"
 echo "OS: $DOS  ARCH: $arch VER: $DVER"
 
 chroot_install=false
+chroot_install=true
 
 if [[ $DOS == "RedHatEnterpriseServer" ]] && [[ $arch == "aarch64" ]]; then
-	chroot_install=true
+	true
 fi
 
 install_grub_chroot() {
+	local disk=$1 target=$2 uefi=$3 arch=$4 class=$5 os=$6
+
 	echo "Attempting to install Grub on $disk"
 	mount --bind /dev "$target/dev"
 	mount --bind /tmp "$target/tmp"
 	mount --bind /proc "$target/proc"
 	mount --bind /sys "$target/sys"
-	chroot "$target" /bin/bash -xe <<EOF
-is_uefi=false
-[[ -d /sys/firmware/efi ]] && {
-	is_uefi=true
-	mountpoint -q /sys/firmware/efi/efivars || {
-		mount -t efivarfs efivarfs /sys/firmware/efi/efivars
-	}
-}
 
-if which grub2-install; then
-	grub2-install --recheck "$disk"
-elif which grub-install; then
-	grub-install --recheck "$disk"
-else
-	echo 'grub-install or grub2-install are not installed on target os'
-	exit 1
-fi
-\$is_uefi && {
-	[ -f /etc/os-release ] && {
-		(
-			source /etc/os-release
-			efibootmgr | tee /dev/stderr | grep -iq "\$ID"
-		)
-	}
-	umount /sys/firmware/efi/efivars
-}
-EOF
-	umount "$target/dev" "$target/tmp" "$target/proc" "$target/sys"
-
-	if $uefi && [[ $plan == "c3.medium.x86" ]] && [[ $DOS == "CentOS" ]]; then
-		add_post_install_service "$target"
-		efi_uuid="$(efi_device "$target/boot/efi" -o partuuid)"
-		efi_id="$(find_uuid_boot_id "$efi_uuid")"
-		echo "Forcing next boot to be target os"
-		efibootmgr -n "$efi_id"
+	didmount=false
+	if "$uefi"; then
+		if ! mountpoint -q "$target/sys/firmware/efi/efivars"; then
+			didmount=true
+			mount -t efivarfs efivarfs "$target/sys/firmware/efi/efivars"
+		fi
+		if [[ $arch == aarch64 ]]; then
+			mount -o remount,ro "$target/sys/firmware/efi/efivars"
+		fi
 	fi
+
+	install -Dm700 target-files/bin/packet-post-install.sh "$target/bin/packet-post-install.sh"
+
+	chroot "$target" /bin/bash <<-EOF
+		$(declare -f install_grub)
+		set -euxo pipefail
+		mount
+		install_grub "$disk" "$uefi" "$arch" "$class" "$os"
+
+	EOF
+	if $didmount; then
+		umount /sys/firmware/efi/efivars
+	fi
+	umount "$target"/{dev,tmp,proc}
+	#umount "$target/sys"
 }
 
-install_grub_osie() {
+install_grub() (
+	#shellcheck disable=SC2030
+	local disk=$1 uefi=$2 arch=$3 class=$4 os=$5
+
+	if which grub2-install &>/dev/null; then
+		grub=grub2
+	elif which grub-install &>/dev/null; then
+		grub=grub-install
+	else
+		echo 'grub-install or grub2-install are not installed on target os'
+		exit 1
+	fi
+
 	echo "Running grub-install on $disk"
 	if ! $uefi; then
-		grub-install --recheck --root-directory="$target" "$disk"
-	else
-		[[ $arch == aarch64 ]] && mount -o remount,ro /sys/firmware/efi/efivars
-
-		grub-install --recheck --bootloader-id=GRUB --root-directory="$target" --efi-directory="$target/boot/efi"
-		grubefi=$(find "$target/boot/efi" -name 'grub*.efi' -print -quit)
-		install -Dm755 "$grubefi" "$target/boot/efi/EFI/BOOT/BOOTX64.EFI"
-
-		if [[ -z $grubefi ]]; then
-			echo "error: couldn't find a suitable grub EFI file"
-			exit 1
-		fi
-
-		if [[ $arch == aarch64 ]]; then
-			echo "Renaming $grubefi to default BOOT binary"
-			install -Dm755 "$grubefi" "$target/boot/efi/EFI/BOOT/BOOTAA64.EFI"
-			install -Dm755 "$grubefi" "$target/boot/efi/EFI/GRUB2/GRUBAA64.EFI"
-		else
-			# grub-install doesn't error if efibootmgr can't actually set the boot entries/order
-			efibootmgr | tee /dev/stderr | grep -iq grub
-		fi
+		# target=/
+		#$grub-install --recheck --root-directory="$target" "$disk"
+		$grub-install --recheck "$disk"
+		return
 	fi
-}
+
+	# target=/
+	#$grub-install --recheck --bootloader-id=ubuntu --root-directory="$target" --efi-directory="$target/boot/efi"
+	$grub-install --recheck --target=x86_64-efi --bootloader-id=centos --efi-directory=/boot/efi
+
+	grubefi=$(find /boot/efi -name 'grub*.efi' -print -quit)
+	if [[ -z ${grubefi:-} ]]; then
+		echo "error: couldn't find a suitable grub EFI file"
+		exit 1
+	fi
+	install -Dm755 "$grubefi" /boot/efi/EFI/BOOT/BOOTX64.EFI
+
+	$grub-mkconfig -o /boot/efi/EFI/centos/grub.cfg
+	mkdir -p /boot/efi/EFI/grub
+	mkdir -p /boot/efi/EFI/centos
+	find /boot
+
+	#cfg=$(find /boot/efi -name grub.cfg)
+	#cp $cfg /boot/efi/EFI/centos/
+	#cp $cfg /boot/efi/EFI/grub/
+	#find /boot/efi -iname grub.cfg
+
+	if [[ $arch == aarch64 ]]; then
+		echo "Renaming $grubefi to default BOOT binary"
+		install -Dm755 "$grubefi" /boot/efi/EFI/BOOT/BOOTAA64.EFI
+		install -Dm755 "$grubefi" /boot/efi/EFI/GRUB2/GRUBAA64.EFI
+	fi
+
+	ID=$os
+	if [[ -f /etc/os-release ]]; then
+		source /etc/os-release
+	fi
+	# grub-install doesn't error if efibootmgr can't actually set the boot entries/order so lets check it
+	efibootmgr | tee /dev/stderr | grep -iq "$ID" || :
+
+	if [[ $class == "c3.medium.x86" ]] && [[ $os == "CentOS" ]]; then
+		cat >"/etc/systemd/system/packet-post-install.service" <<-EOF
+			[Unit]
+			Description=Packet post install setup
+			After=multi-user.target
+			[Service]
+			Type=oneshot
+			ExecStart=/bin/packet-post-install.sh
+			[Install]
+			WantedBy=multi-user.target
+		EOF
+		ln -s /etc/systemd/system/packet-post-install.service /etc/systemd/system/multi-user.target.wants/packet-post-install.service
+
+		efi_uuid=$(findmnt -n --target /boot/efi -o partuuid)
+		efi_id=$(efibootmgr -v | grep "$efi_uuid" | sed 's/^Boot\([0-9a-f]\{4\}\).*/\1/gI;t;d')
+
+		echo "Forcing next boot to be target os"
+		efibootmgr -n "$efi_id"
+	else
+		rm -f /bin/packet-post-install.sh
+	fi
+)
 
 # shellcheck disable=SC2207
 bootdevs=$(jq -r '.bootdevs[]' "$cprout")
 [[ -n $bootdevs ]]
 for disk in $bootdevs; do
 	if $chroot_install; then
-		install_grub_chroot
+		#shellcheck disable=SC2031
+		install_grub_chroot "$disk" "$target" "$uefi" "$arch" "$class" "$DOS"
 	else
-		install_grub_osie
+		#shellcheck disable=SC2031
+		install_grub "$disk" "$target" "$uefi" "$arch" "$class" "$DOS"
 	fi
 done

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -162,9 +162,9 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 	mkdir $assetdir
 	set_autofail_stage "OS image fetch"
 	echo -e "${GREEN}#### Fetching image (and more) via git ${NC}"
-	configure_image_cache_dns
 
 	if [[ ${OS} =~ : && $custom_image == false ]]; then
+		configure_image_cache_dns
 		image_tag=$(echo "$OS" | awk -F':' '{print $2}')
 
 		githost="github-mirror.packet.net"
@@ -182,10 +182,6 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 		# TODO - figure how we can do SSL passthru for github-cloud to images cache
 		git config --global http.sslverify false
 	elif [[ $custom_image == true ]]; then
-		if [[ ${image_repo} =~ github ]]; then
-			git config --global http.sslverify false
-		fi
-
 		gituri="${image_repo}"
 	fi
 	# Silence verbose notice about deatched HEAD state


### PR DESCRIPTION
## Description

Makes osie install uefi with --bootloader-id=ubuntu.

## Why is this needed

Recent Ubuntu grub updates to fix the BootHole vulnerabilities ended up
hard coding the grub config lookup from \efi\ubuntu, but `grub-install --bootloader-id=grub`
places it into `\efi\grub`. Boot failures ensue.

## How Has This Been Tested?

Modified `ci/vm.sh` to boot the installed VM.
I was able to reproduce the boot hang without this change and no issues after.
