### PR TITLE
Shrink saved docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,14 +3,6 @@ FROM ubuntu:xenial
 VOLUME /statedir
 ENTRYPOINT ["/entrypoint.sh"]
 
-ARG GITVERSION
-ARG GITBRANCH
-ARG DRONEBUILD
-
-ENV OSIE_VERSION ${GITVERSION}
-ENV OSIE_BRANCH ${GITBRANCH}
-ENV DRONE_BUILD ${DRONEBUILD}
-
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 
@@ -187,6 +179,11 @@ RUN curl --remote-name "https://raw.githubusercontent.com/packethost/metal-block
 
 COPY entrypoint.sh /entrypoint.sh
 COPY scripts/ /home/packet/
+
+ARG GITVERSION
+ARG GITBRANCH
+ARG DRONEBUILD
+ENV OSIE_VERSION=${GITVERSION} OSIE_BRANCH=${GITBRANCH} DRONE_BUILD=${DRONEBUILD}
 
 # ensure we always have up to date packages
 RUN apt-get -y update && \

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -4,14 +4,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python3", "run.py"]
 VOLUME /statedir
 
-ARG GITVERSION
-ARG GITBRANCH
-ARG DRONEBUILD
-
-ENV OSIE_VERSION ${GITVERSION}
-ENV OSIE_BRANCH ${GITBRANCH}
-ENV DRONE_BUILD ${DRONEBUILD}
-
 WORKDIR /tmp
 RUN apk add --update --upgrade --no-cache bash docker jq libstdc++ python3
 COPY requirements.txt .
@@ -26,3 +18,8 @@ RUN apk add --update --upgrade --no-cache --virtual build-deps alpine-sdk curl l
 WORKDIR /
 
 ADD entrypoint.sh *.py /
+
+ARG GITVERSION
+ARG GITBRANCH
+ARG DRONEBUILD
+ENV OSIE_VERSION=${GITVERSION} OSIE_BRANCH=${GITBRANCH} DRONE_BUILD=${DRONEBUILD}

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -220,9 +220,8 @@ build/osie-x86_64.tar.gz:  SED=
 build/osie-%.tar.gz: docker/Dockerfile ${osiesrcs}
 	$(E) "DOCKER   $@"
 	$(Q) sed '${SED}' $< > $<.$*
-	$(Q) docker build --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
-	$(Q) docker save osie:$* > $@.tmp
-	$(Q) mv $@.tmp $@
+	$(Q) docker build --squash --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
+	$(Q) docker save osie:$* | pigz >$@
 
 ifneq ($(CI),drone)
 build/osie-runner-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64
@@ -232,9 +231,8 @@ build/osie-runner-x86_64.tar.gz:  SED=
 build/osie-runner-%.tar.gz: osie-runner/Dockerfile $(shell git ls-files osie-runner)
 	$(E) "DOCKER   $@"
 	$(Q) sed '${SED}' $< > $<.$*
-	$(Q) docker build --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie-runner:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
-	$(Q) docker save osie-runner:$* > $@.tmp
-	$(Q) mv $@.tmp $@
+	$(Q) docker build --squash --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie-runner:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
+	$(Q) docker save osie-runner:$* | pigz >$@
 
 build/osie-runner-aarch64.tar.gz:
 	$(E) "FAKE     $@"


### PR DESCRIPTION
## Description

Shrink the saved/exported docker size by squashing and compressing.

## Why is this needed

Images are larger than necessary, lets save some bits.

Fixes #2

## How Has This Been Tested?

VM tests


## How are existing users impacted? What migration steps/scripts do we need?

Smaller fetches from the internet, quicker docker load times.
