### PR TITLE
Some simple makefile QoL improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
 -include rules.mk
 
+all: build/$v/osie-aarch64.tar.gz build/$v/osie-x86_64.tar.gz
+
+package: build/$v.tar.gz build/$v.tar.gz.sha512sum
+
+package-common: package-apps package-grubs
+
+deploy: deploy-to-s3
+
+test: test-aarch64 test-x86_64
+	
 rules.mk: rules.mk.j2 rules.mk.json
 	@j2 -f json $^ > $@

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
--include rules.mk
-
-all: build/$v/osie-aarch64.tar.gz build/$v/osie-x86_64.tar.gz
-
-package: build/$v.tar.gz build/$v.tar.gz.sha512sum
-
-package-common: package-apps package-grubs
-
-deploy: deploy-to-s3
-
-test: test-aarch64 test-x86_64
+help: ## Print this help
+	@grep --no-filename -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/:.*##/·/' | sort | column -ts '·' -c 120
 	
 rules.mk: rules.mk.j2 rules.mk.json
 	@j2 -f json $^ > $@
+
+-include rules.mk
+
+all: build/$v/osie-aarch64.tar.gz build/$v/osie-x86_64.tar.gz ## Build the osie container images
+
+package: build/$v.tar.gz build/$v.tar.gz.sha512sum  ## Bundle up all the files needed for an OSIE release
+
+package-common: package-apps package-grubs ## Bundle up all the architecture independent files
+
+deploy: deploy-to-s3 ## Upload the packaged release to S3
+
+test: test-aarch64 test-x86_64 ## Run VM based tests

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,20 @@ MAKEFLAGS += --no-builtin-rules
 # Delete target files if there's an error
 # This avoids a failure to then skip building on next run if the output is created by shell redirection for example
 .DELETE_ON_ERROR:
+# Treat the whole recipe as a one shell script/invocation instead of one-per-line
+.ONESHELL:
 # Use bash instead of plain sh
 SHELL := bash
 .SHELLFLAGS := -o pipefail -euc
 
-E=@echo
 ifeq ($(V),1)
-Q=
+E := :
 else
-Q=@
+E := @echo
 endif
 
 -include rules.mk
 
 rules.mk: rules.mk.j2 rules.mk.json
 	$(E) "JINJA    $@"
-	$(Q) j2 -f json $^ > $@
+	j2 -f json $^ > $@

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,4 @@
-# Only use the recipes defined in these makefiles
-MAKEFLAGS += --no-builtin-rules
-.SUFFIXES:
-# Delete target files if there's an error
-# This avoids a failure to then skip building on next run if the output is created by shell redirection for example
-.DELETE_ON_ERROR:
-# Treat the whole recipe as a one shell script/invocation instead of one-per-line
-.ONESHELL:
-# Use bash instead of plain sh
-SHELL := bash
-.SHELLFLAGS := -o pipefail -euc
-
-ifeq ($(V),1)
-E := :
-else
-E := @echo
-endif
-
 -include rules.mk
 
 rules.mk: rules.mk.j2 rules.mk.json
-	$(E) "JINJA    $@"
-	j2 -f json $^ > $@
+	@j2 -f json $^ > $@

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-SHELL := bash
-.SHELLFLAGS := -o pipefail -c
-
+# Only use the recipes defined in these makefiles
+MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
-MAKEFLAGS +=  --no-builtin-rules
-
+# Delete target files if there's an error
+# This avoids a failure to then skip building on next run if the output is created by shell redirection for example
 .DELETE_ON_ERROR:
+# Use bash instead of plain sh
+SHELL := bash
+.SHELLFLAGS := -o pipefail -euc
 
 E=@echo
 ifeq ($(V),1)

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -71,8 +71,6 @@ T := null
 endif
 
 .PHONY: all deploy package package-apps package-grubs test test-aarch6 test-x86_64 v
-all: build/$v/osie-aarch64.tar.gz build/$v/osie-x86_64.tar.gz
-test: test-aarch64 test-x86_64
 v:
 	@echo $v
 
@@ -92,8 +90,6 @@ package-{{platform}}: ${packaged-{{platform}}}
 packages += ${packaged-{{platform}}}
 {% endfor %}
 
-package: build/$v.tar.gz build/$v.tar.gz.sha512sum
-package-common: package-apps package-grubs
 package-apps: ${packaged-apps}
 package-grubs: ${packaged-grubs}
 package-osies: ${packaged-osies}
@@ -103,7 +99,7 @@ s3Bucket := tinkerbell-oss
 ifdef DRONE_PULL_REQUEST
 s3Bucket := tinkerbell-oss-pr
 endif
-deploy: package
+deploy-to-s3: package
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/$v.tar.gz"
 	mc cp build/$v.tar.gz s3/${s3Bucket}/osie-uploads/$v.tar.gz
 	if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz s3/tinkerbell-oss/osie-uploads/latest.tar.gz; fi

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -70,7 +70,7 @@ override undefine T
 T := null
 endif
 
-.PHONY: all deploy package package-apps package-grubs test test-aarch6 test-x86_64 v
+.PHONY: all deploy package package-apps package-grubs test test-aarch64 test-x86_64 v
 v:
 	@echo $v
 

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -1,5 +1,17 @@
 # vim: set filetype=make :
 
+# Only use the recipes defined in these makefiles
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+# Delete target files if there's an error
+# This avoids a failure to then skip building on next run if the output is created by shell redirection for example
+.DELETE_ON_ERROR:
+# Treat the whole recipe as a one shell script/invocation instead of one-per-line
+.ONESHELL:
+# Use bash instead of plain sh
+SHELL := bash
+.SHELLFLAGS := -o pipefail -euc
+
 alpine_version_aarch64 := 3.4
 alpine_version_x86_64 := 3.12
 
@@ -44,12 +56,10 @@ cprs := $(shell git ls-files ci/cpr/)
 grubs := $(shell git ls-files grub/)
 osiesrcs := $(shell git ls-files docker/)
 
-E=@echo
-E+=
 ifeq ($(V),1)
-Q=
+E := :
 else
-Q=@
+E := @echo
 endif
 
 ifeq ($(T),1)

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -215,8 +215,7 @@ build/$v-rootfs-%: build/initramfs-%
 build/discover-metal-x86_64.tar.gz:
 	$(E) "DOCKER   $@"
 	docker pull quay.io/packet/discover-metal 2>&1 | tee $@.log >/dev/$T
-	docker save quay.io/packet/discover-metal:latest > $@.tmp
-	mv $@.tmp $@
+	docker save quay.io/packet/discover-metal:latest | pigz >$@
 
 ifneq ($(CI),drone)
 build/osie-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -190,7 +190,7 @@ ifneq ($(CI),drone)
 test-{{arch}}: /proc/sys/fs/binfmt_misc/qemu-aarch64
 endif
 {% endif %}
-test-{{arch}}: $(cprs) build/osie-test-env package-apps package-grubs build/$v/osie-{{arch}}.tar.gz build/$v/osie-runner-{{arch}}.tar.gz build/$v/repo-{{arch}} ${packaged-{{arch}}} ci/ifup.sh ci/vm.sh build/$v/test-initramfs-{{arch}}/test-initramfs
+test-{{arch}}: $(cprs) build/osie-test-env package-apps package-grubs build/$v/osie-{{arch}}.tar.gz build/$v/osie-runner-{{arch}}.tar.gz build/$v/repo-{{arch}} ${packaged-{{arch}}} ci/ifup.sh ci/vm.sh build/$v/test-initramfs-{{arch}}/test-initramfs ## Run VM based tests for {{arch}}
 	$(E) "DOCKER   $@"
 ifneq ($(CI),drone)
 	docker run --rm -ti \

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -95,84 +95,84 @@ s3Bucket := tinkerbell-oss-pr
 endif
 deploy: package
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/$v.tar.gz"
-	$(Q) mc cp build/$v.tar.gz s3/${s3Bucket}/osie-uploads/$v.tar.gz
-	$(Q) if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz s3/tinkerbell-oss/osie-uploads/latest.tar.gz; fi
+	mc cp build/$v.tar.gz s3/${s3Bucket}/osie-uploads/$v.tar.gz
+	if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz s3/tinkerbell-oss/osie-uploads/latest.tar.gz; fi
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/$v.tar.gz.sha512sum"
-	$(Q) mc cp build/$v.tar.gz.sha512sum s3/${s3Bucket}/osie-uploads/$v.tar.gz.sha512sum
-	$(Q) if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz.sha512sum s3/tinkerbell-oss/osie-uploads/latest.tar.gz.sha512sum; fi
-	$(Q) echo "deploy this build from the deploy-osie repo with the following command:"
-	$(Q) echo -n "./deploy update $v -m \"$$"
-	$(Q) echo -n "(sed -n '/^## \[/,$$ {/\S/!q; p}' CHANGELOG.md)\" "
-	$(Q) echo -n "$$(sed 's|.*= ||' build/$v.tar.gz.sha512sum)"
-	$(Q) echo
+	mc cp build/$v.tar.gz.sha512sum s3/${s3Bucket}/osie-uploads/$v.tar.gz.sha512sum
+	if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then mc cp s3/tinkerbell-oss/osie-uploads/$v.tar.gz.sha512sum s3/tinkerbell-oss/osie-uploads/latest.tar.gz.sha512sum; fi
+	echo "deploy this build from the deploy-osie repo with the following command:"
+	echo -n "./deploy update $v -m \"$$"
+	echo -n "(sed -n '/^## \[/,$$ {/\S/!q; p}' CHANGELOG.md)\" "
+	echo -n "$$(sed 's|.*= ||' build/$v.tar.gz.sha512sum)"
+	echo
 
 upload-test: ${packages}
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/osie-testing/$v/"
-	$(Q) mc cp --recursive build/$v/ s3/tinkerbell-oss/osie-uploads/osie-testing/$v/ || ( \
-		session=$$(mc session list --json | jq -r .sessionId); \
-		for i in {1..5}; do \
-			mc session resume $$session && exit 0; \
-		done; \
-		mc session clear $$sesion; \
-		exit 1; \
+	mc cp --recursive build/$v/ s3/tinkerbell-oss/osie-uploads/osie-testing/$v/ || (
+		session=$$(mc session list --json | jq -r .sessionId)
+		for i in {1..5}; do
+			mc session resume $$session && exit 0
+		done
+		mc session clear $$sesion
+		exit 1
 	)
 
 build/$v.tar.gz: ${packages}
 	$(E) "TAR.GZ   $@"
-	$(Q) cd build && \
-		tar -cO $(sort $(subst build/,,$^)) | pigz >$(@F)
+	cd build
+	tar -cO $(sort $(subst build/,,$^)) | pigz >$(@F)
 
 build/$v.tar.gz.sha512sum: build/$v.tar.gz
 	$(E) "SHASUM   $@"
-	$(Q) sha512sum --tag $^ | sed 's|build/||' >$@
+	sha512sum --tag $^ | sed 's|build/||' >$@
 
 ${packaged-grubs}: ${grubs}
 	$(E) "INSTALL  $@"
-	$(Q) install -Dm644 $(addprefix grub/,$(subst /,-,$(patsubst build/$v/grub/%,%,$@))) $@
+	install -Dm644 $(addprefix grub/,$(subst /,-,$(patsubst build/$v/grub/%,%,$@))) $@
 
 build/$v/%-rc: apps/%-rc
 	$(E) "INSTALL  $@"
-	$(Q) install -D -m644 $< $@
+	install -D -m644 $< $@
 
 build/$v/%.sh: apps/%.sh
 	$(E) "INSTALL  $@"
-	$(Q) install -D -m644 $< $@
+	install -D -m644 $< $@
 
 build/$v/%.tar.gz: build/%.tar.gz
 	$(E) "INSTALL  $@"
-	$(Q) install -D -m644 $< $@
+	install -D -m644 $< $@
 
 {% for platform, arch in platforms.items() %}
 build/$v/initramfs-{{platform}}: build/$v-rootfs-{{platform}} installer/alpine/init-{{arch}}
 	$(E) "CPIO     $@"
-	$(Q) install -m755 installer/alpine/init-{{arch}} build/$v-rootfs-{{platform}}/init
-	$(Q) (cd build/$v-rootfs-{{platform}} && find -print0 | bsdcpio --null --quiet -oH newc | pigz -9) >$@.osied
-	$(Q) install -D -m644 $@.osied $@
-	$(Q) touch $@
+	install -m755 installer/alpine/init-{{arch}} build/$v-rootfs-{{platform}}/init
+	(cd build/$v-rootfs-{{platform}} && find -print0 | bsdcpio --null --quiet -oH newc | pigz -9) >$@.osied
+	install -D -m644 $@.osied $@
+	touch $@
 {% endfor %}
 
 build/$v/modloop-%: build/modloop-%
 	$(E) "INSTALL  $@"
-	$(Q) install -D -m644 $< $@
+	install -D -m644 $< $@
 
 build/$v/vmlinuz-%: build/vmlinuz-%
 	$(E) "INSTALL  $@"
-	$(Q) install -D -m644 $< $@
+	install -D -m644 $< $@
 
 build/$v/test-initramfs-%/test-initramfs: build/$v/initramfs-% installer/alpine/init-%
 	$(E) "BUILD    $@"
-	$(Q) rm -rf $(@D)
-	$(Q) mkdir -p $(@D)
-	$(Q) cp $^ $(@D)/
-	$(Q) mv $(@D)/$(<F) $(@D)/initramfs.cpio.gz
-	$(Q) cd $(@D) && \
-		sed -i 's|curl |curl --insecure |g' init-* && \
-		mv init-* init && \
-		chmod +x init && \
-		unpigz initramfs.cpio.gz && \
-		echo init | cpio -oH newc --append -O initramfs.cpio && \
-		pigz -9 initramfs.cpio && \
-		mv initramfs.cpio.gz $(@F)
+	rm -rf $(@D)
+	mkdir -p $(@D)
+	cp $^ $(@D)/
+	mv $(@D)/$(<F) $(@D)/initramfs.cpio.gz
+	cd $(@D)
+	sed -i 's|curl |curl --insecure |g' init-*
+	mv init-* init
+	chmod +x init
+	unpigz initramfs.cpio.gz
+	echo init | cpio -oH newc --append -O initramfs.cpio
+	pigz -9 initramfs.cpio
+	mv initramfs.cpio.gz $(@F)
 
 build/osie-test-env: ci/Dockerfile
 	docker build -t osie-test-env ci 2>&1 | tee $@.log >/dev/$T
@@ -187,7 +187,7 @@ endif
 test-{{arch}}: $(cprs) build/osie-test-env package-apps package-grubs build/$v/osie-{{arch}}.tar.gz build/$v/osie-runner-{{arch}}.tar.gz build/$v/repo-{{arch}} ${packaged-{{arch}}} ci/ifup.sh ci/vm.sh build/$v/test-initramfs-{{arch}}/test-initramfs
 	$(E) "DOCKER   $@"
 ifneq ($(CI),drone)
-	$(Q) docker run --rm -ti \
+	docker run --rm -ti \
 		--privileged \
 		--name $(@F) \
 		--volume $(CURDIR):/osie:ro \
@@ -202,15 +202,15 @@ endif
 
 build/$v-rootfs-%: build/initramfs-%
 	$(E) "EXTRACT  $@"
-	$(Q) rm -rf $@
-	$(Q) mkdir $@
-	$(Q) bsdtar -xf $< -C $@
+	rm -rf $@
+	mkdir $@
+	bsdtar -xf $< -C $@
 
 build/discover-metal-x86_64.tar.gz:
 	$(E) "DOCKER   $@"
-	$(Q) docker pull quay.io/packet/discover-metal 2>&1 | tee $@.log >/dev/$T
-	$(Q) docker save quay.io/packet/discover-metal:latest > $@.tmp
-	$(Q) mv $@.tmp $@
+	docker pull quay.io/packet/discover-metal 2>&1 | tee $@.log >/dev/$T
+	docker save quay.io/packet/discover-metal:latest > $@.tmp
+	mv $@.tmp $@
 
 ifneq ($(CI),drone)
 build/osie-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64
@@ -219,9 +219,9 @@ build/osie-aarch64.tar.gz: SED=/FROM/ s|.*|FROM multiarch/ubuntu-debootstrap:arm
 build/osie-x86_64.tar.gz:  SED=
 build/osie-%.tar.gz: docker/Dockerfile ${osiesrcs}
 	$(E) "DOCKER   $@"
-	$(Q) sed '${SED}' $< > $<.$*
-	$(Q) docker build --squash --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
-	$(Q) docker save osie:$* | pigz >$@
+	sed '${SED}' $< > $<.$*
+	docker build --squash --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
+	docker save osie:$* | pigz >$@
 
 ifneq ($(CI),drone)
 build/osie-runner-aarch64.tar.gz: /proc/sys/fs/binfmt_misc/qemu-aarch64
@@ -230,27 +230,27 @@ build/osie-runner-aarch64.tar.gz: SED=/FROM/ s|.*|FROM multiarch/alpine:arm64-v3
 build/osie-runner-x86_64.tar.gz:  SED=
 build/osie-runner-%.tar.gz: osie-runner/Dockerfile $(shell git ls-files osie-runner)
 	$(E) "DOCKER   $@"
-	$(Q) sed '${SED}' $< > $<.$*
-	$(Q) docker build --squash --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie-runner:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
-	$(Q) docker save osie-runner:$* | pigz >$@
+	sed '${SED}' $< > $<.$*
+	docker build --squash --build-arg GITVERSION=${gitversion} --build-arg GITBRANCH=${gitbranch} --build-arg DRONEBUILD=${dronebuild} -t osie-runner:$* -f $<.$* $(<D) 2>&1 | tee $@.log >/dev/$T
+	docker save osie-runner:$* | pigz >$@
 
 build/osie-runner-aarch64.tar.gz:
 	$(E) "FAKE     $@"
-	$(Q) touch $@
+	touch $@
 
 build/$v/repo-aarch64:
 	$(E) "LN       $@"
-	$(Q) ln -nsf ../../../alpine/edge $@
+	ln -nsf ../../../alpine/edge $@
 
 build/repo-aarch64:
-	$(Q) echo edge > $@
+	echo edge > $@
 
 build/$v/repo-x86_64:
 	$(E) "LN       $@"
-	$(Q) ln -nsf ../../../alpine/v${alpine_version_x86_64} $@
+	ln -nsf ../../../alpine/v${alpine_version_x86_64} $@
 
 build/repo-x86_64:
-	$(Q) echo v${alpine_version_x86_64} > $@
+	echo v${alpine_version_x86_64} > $@
 
 {% for platform in platforms %}
 build/initramfs-{{platform}}: installer/alpine/assets-{{platform}}/initramfs
@@ -258,7 +258,7 @@ build/modloop-{{platform}}:   installer/alpine/assets-{{platform}}/modloop
 build/vmlinuz-{{platform}}:   installer/alpine/assets-{{platform}}/vmlinuz
 build/initramfs-{{platform}} build/modloop-{{platform}} build/vmlinuz-{{platform}}:
 	$(E) "LN       $@"
-	$(Q) ln -nsf ../$< $@
+	ln -nsf ../$< $@
 {% endfor -%}
 
 assets-aarch64: installer/alpine/assets-aarch64/initramfs installer/alpine/assets-aarch64/modloop installer/alpine/assets-aarch64/vmlinuz
@@ -267,23 +267,23 @@ build/osie-alpine-initramfs-builder-aarch64: /proc/sys/fs/binfmt_misc/qemu-aarch
 endif
 build/osie-alpine-initramfs-builder-aarch64: installer/alpine/Dockerfile installer/alpine/build.sh installer/alpine/eclypsiumdriver-alpine-* installer/alpine/qemu-aarch64-static
 	$(E) "IMAGE $@"
-	$(Q) sed '/^FROM alpine/ s| .*| arm64v8/alpine:3.6\nCOPY qemu-aarch64-static /usr/bin|' installer/alpine/Dockerfile >installer/alpine/Dockerfile.aarch64
-	$(Q) docker build -f installer/alpine/Dockerfile.aarch64 -t $@ installer/alpine/ 2>&1 | tee $@.log >/dev/$T
-	$(Q) touch $@
+	sed '/^FROM alpine/ s| .*| arm64v8/alpine:3.6\nCOPY qemu-aarch64-static /usr/bin|' installer/alpine/Dockerfile >installer/alpine/Dockerfile.aarch64
+	docker build -f installer/alpine/Dockerfile.aarch64 -t $@ installer/alpine/ 2>&1 | tee $@.log >/dev/$T
+	touch $@
 
 assets-x86_64: installer/alpine/assets-x86_64/initramfs installer/alpine/assets-x86_64/modloop installer/alpine/assets-x86_64/vmlinuz
 build/osie-alpine-initramfs-builder-x86_64:  installer/alpine/Dockerfile installer/alpine/build.sh installer/alpine/eclypsiumdriver-alpine-*
 	$(E) "IMAGE $@"
-	$(Q) docker build -f installer/alpine/Dockerfile -t $@ installer/alpine/ 2>&1 | tee $@.log >/dev/$T
-	$(Q) touch $@
+	docker build -f installer/alpine/Dockerfile -t $@ installer/alpine/ 2>&1 | tee $@.log >/dev/$T
+	touch $@
 installer/alpine/assets-x86_64/initramfs installer/alpine/assets-x86_64/modloop installer/alpine/assets-x86_64/vmlinuz: build/osie-alpine-initramfs-builder-x86_64
 	$(E) "BUILD $@"
-	$(Q) docker run --rm -v ${PWD}/${@D}/:/assets/ --name=osie-assets-x86_64-${@F} $< ${@F} 2>&1 | tee build/osie-assets-x86_64-${@F}.log >/dev/$T
+	docker run --rm -v ${PWD}/${@D}/:/assets/ --name=osie-assets-x86_64-${@F} $< ${@F} 2>&1 | tee build/osie-assets-x86_64-${@F}.log >/dev/$T
 
 installer/alpine/qemu-aarch64-static:
 	$(E) "GET   $@"
-	$(Q) wget https://github.com/multiarch/qemu-user-static/releases/download/v5.0.0-2/$(@F) -O $@
-	$(Q) chmod 755 $@
+	wget https://github.com/multiarch/qemu-user-static/releases/download/v5.0.0-2/$(@F) -O $@
+	chmod 755 $@
 
 /proc/sys/fs/binfmt_misc/qemu-aarch64:
 	$(E) 'You need to configure qemu-aarch64-static for aarch64 programs, for example:'


### PR DESCRIPTION
## Description

Adds a `help` target that shows some nice help message for the "main" targets and changes
the default target to `help`:

```ShellSession
$ make
all              Build the osie container images
deploy           Upload the packaged release to S3
help             Print this help
package          Bundle up all the files needed for an OSIE release
package-common   Bundle up all the architecture independent files
test-aarch64     Run VM based tests for aarch64
test             Run VM based tests
test-x86_64      Run VM based tests for x86_64
```

Also adds .ONESHELL config which makes the recipes simpler since its not one shell invocation per line.
