### PR TITLE
Test VM poweron, boot, and phonehome

### DIFF
--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -113,7 +113,7 @@ gen_metadata() {
 		      }
 		    ],
 		    "bonding": {
-		      "mode": 5
+		      "link_aggregation": "individual"
 		    },
 		    "interfaces": [
 		      {

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -245,6 +245,9 @@ teardown() {
 
 }
 
+# This function exec's the last binary run, this seems weird but actually works out ok.
+# Bash ends up running this function in subprocesses so the exec replace run_vm's process not ci/vm.sh's
+# This is needed so that run_vm callers will get qemu's pid and can kill it (otherwise bash won't forward the SIGTERM received by the function)
 run_vm() {
 	local cpu='' machine=''
 
@@ -281,7 +284,7 @@ run_vm() {
 	esac
 
 	# shellcheck disable=SC2068
-	"qemu-system-$arch" \
+	exec "qemu-system-$arch" \
 		"$@" \
 		-monitor unix:monitor.sock,server=on,wait=off \
 		-nographic \

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -59,8 +59,7 @@ make_disk() {
 }
 
 gen_metadata() {
-	local class=$1 slug=$2 tag=$3
-	id=$(uuidgen)
+	local class=$1 slug=$2 tag=$3 id=$4
 
 	local cprcmd
 	cprcmd=(cat)
@@ -320,8 +319,9 @@ do_test() {
 
 	configure_nics
 
+	id=$(uuidgen)
 	# rename disk from scsi names to virtio names, e.g. sda1 -> vda1
-	gen_metadata "$class" "$slug" "$tag" <"$scriptdir/cpr/$class.cpr.json"
+	gen_metadata "$class" "$slug" "$tag" "$id" <"$scriptdir/cpr/$class.cpr.json"
 
 	start_dhcp \
 		--dhcp-host="${macs[0]},$pubip4" \

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -200,10 +200,12 @@ start_web() {
 		}
 
 		metadata.packet.net:80 {
+		    browse
 		    log stderr
 		}
 
 		metadata.packet.net:443 {
+		    browse
 		    log stderr
 		    tls server.pem server-key.pem
 		}

--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -263,7 +263,9 @@ run_vm() {
 	if [[ $UEFI != 'true' ]]; then
 		bios=('-bios' '/usr/share/qemu/bios.bin')
 	else
-		cp /usr/share/OVMF/OVMF_VARS.fd "$disk.vars"
+		if ! [[ -f "$disk.vars" ]]; then
+			cp /usr/share/OVMF/OVMF_VARS.fd "$disk.vars"
+		fi
 		if [[ $arch == x86_64 ]]; then
 			bios=(
 				-drive 'if=pflash,format=raw,file=/usr/share/OVMF/OVMF_CODE.fd,readonly'

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -370,7 +370,10 @@ EOF
 			  Ec2:
 			    timeout: 60
 			    max_wait: 120
-			    metadata_urls: [ 'http://metadata.packet.net', 'http://147.75.207.1:80' ]
+			    metadata_urls:
+			      - https://metadata.packet.net
+			      - http://metadata.packet.net
+			      - http://147.75.207.1
 			    dsmode: net
 			disable_root: 0
 			package_reboot_if_required: false


### PR DESCRIPTION
## Description

Add power on + boot from disk + expect phone home test to the VM based tests.

## Why is this needed

We hit #226 in production because we don't boot test osie.sh installations.

## How Has This Been Tested?

`make test-x86_64 test_aarch64`.

## How are existing users impacted? What migration steps/scripts do we need?

Legacy code, only EM is known to be impacted.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
