### PR TITLE
Pin grub to known working version

### DIFF
--- a/docker/get-package-list.sh
+++ b/docker/get-package-list.sh
@@ -6,6 +6,33 @@ x86_64) grub_efi_arch=amd64 ;;
 *) echo "unknown arch" && exit 1 ;;
 esac
 
+# pin grub to last known (but buggy!) versions
+cat >/etc/apt/preferences <<-EOF
+	Package: grub2
+	Pin: version 2.02~beta2-36ubuntu3.27
+	Pin-Priority: 999
+
+	Package: grub2-common
+	Pin: version 2.02~beta2-36ubuntu3.27
+	Pin-Priority: 999
+
+	Package: grub-common
+	Pin: version 2.02~beta2-36ubuntu3.27
+	Pin-Priority: 999
+
+	Package: grub-efi-$grub_efi_arch
+	Pin: version 2.02~beta2-36ubuntu3.27
+	Pin-Priority: 999
+
+	Package: grub-efi-$grub_efi_arch-bin
+	Pin: version 2.02~beta2-36ubuntu3.27
+	Pin-Priority: 999
+
+	Package: grub-pc-bin
+	Pin: version 2.02~beta2-36ubuntu3.27
+	Pin-Priority: 999
+EOF
+
 # shellcheck disable=SC2206
 packages=(
 	binutils


### PR DESCRIPTION
## Description

Pin grub to pre-Boothole "fixes" that break non secure boot uefi boots.

## Why is this needed

Temporarily unblocks master due to #226.

## How Has This Been Tested?

Tested on top of #227 on my dev machine.

## How are existing users impacted? What migration steps/scripts do we need?

OSIE can be deployed/run while waiting on #228 to land.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
