### PR TITLE
DEL-207 - add metadata IP to urls

### DIFF
--- a/docker/scripts/frosie.sh
+++ b/docker/scripts/frosie.sh
@@ -316,7 +316,7 @@ if [ -f "$target/usr/local/etc/cloud/cloud.cfg" ]; then
 		  Ec2:
 		    timeout: 60
 		    max_wait: 120
-		    metadata_urls: [ 'https://metadata.packet.net' ]
+		    metadata_urls: [ 'http://metadata.packet.net', 'http://147.75.207.1:80' ]
 		    dsmode: net
 		cloud_init_modules:
 		 - migrator

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -357,7 +357,7 @@ EOF
 			  Ec2:
 			    timeout: 60
 			    max_wait: 120
-			    metadata_urls: [ 'https://metadata.packet.net' ]
+			    metadata_urls: [ 'http://metadata.packet.net', 'http://147.75.207.1:80' ]
 			    dsmode: net
 			disable_root: 0
 			package_reboot_if_required: false

--- a/docker/scripts/vosie.sh
+++ b/docker/scripts/vosie.sh
@@ -342,7 +342,7 @@ if [ -f $target/etc/cloud/cloud.cfg ]; then
 		  Ec2:
 		    timeout: 60
 		    max_wait: 120
-		    metadata_urls: [ 'https://metadata.packet.net' ]
+		    metadata_urls: [ 'http://metadata.packet.net', 'http://147.75.207.1:80' ]
 		    dsmode: net
 		cloud_init_modules:
 		 - DataSourceEc2


### PR DESCRIPTION
This is re-PR of a previously reverted change in https://github.com/tinkerbell/osie/pull/214 to add the new kant IP to the list of metadata_urls. 

### Testing 

Tested using the following userdata: 

```
#cloud-config
#services={"osie":"sfunk-metadata-take-2"}
```

### Cloud init logs example

Cloud init logs have both resolving:
```
2021-06-17 13:48:48,832 - util.py[DEBUG]: Resolving URL: http://metadata.packet.net took 9.110 seconds
2021-06-17 13:48:48,832 - util.py[DEBUG]: Resolving URL: http://147.75.207.1:80 took 0.000 seconds
2021-06-17 13:48:48,832 - url_helper.py[DEBUG]: [0/1] open 'http://metadata.packet.net/2009-04-04/meta-data/instance-id' with {'url': 'http://metadata.packet.net/2009-04-04/meta-data/instance-id', 'allow_redirects': True, 'method': 'GET', 'timeout': 60.0} configuration
```

### Using `ubuntu 20.04`: 

Successful on a `c3.medium.x86`: https://staff.equinixmetal.net/instances/64454dbb-cda9-4279-b555-b886a99d6698/overview

Successful on a `c1.large.arm`: https://staff.equinixmetal.net/instances/45b61ae9-41b1-41f9-8450-2708de1ee5a7/overview

Successful on `f3.large.x86` (efi): https://staff.equinixmetal.net/instances/e92b284a-f94f-4c9b-8b3b-6f8a4629b380/overview

Successful on `c1.small.x86`: https://staff.equinixmetal.net/instances/b801c9e2-1c80-42ec-9a77-adba3d1e8f3a/overview

### Using `ubuntu 18.04`:

Successful on `c1.large.arm`: https://staff.equinixmetal.net/instances/5ae7bb42-5800-44ad-8683-853c07fb32b6/overview

### Failed Provisions 

I have 1 failed provision in my tests on an f3.large.x86 but this was due to timeouts phone-home to tinkerbell and unrelated to this change and not an issue with being stuck on grub. 