### PR TITLE
Load sg module before starting tink-worker

### DIFF
--- a/apps/workflow-helper.sh
+++ b/apps/workflow-helper.sh
@@ -74,6 +74,11 @@ rm -f /sbin/mdev
 
 mkdir /worker
 
+# Certain workflow actions require access to the 'sg' device
+# We load the 'sg' module here to enable that, but should probably
+# load the module within the action(s) requring it
+modprobe sg
+
 # tink-worker has been updated to use ID rather than WORKER_ID
 # TODO: remove setting WORKER_ID when we no longer want to support backwards compatibility
 # with the older tink-worker


### PR DESCRIPTION
## Description

Ensure the 'sg' module is loaded before starting tink-worker to enable the use of utilities such as mvcli (Marvell storage controllers).

## Why is this needed

Certain workflow actions (specifically deprovision) require access to the sg (scsi generic) device to manipulate RAID controllers.     Historically this was loaded in osie-installer just before deprovision.sh was called, but this was 'lost' when converting to workflow actions.

## How Has This Been Tested?

workflow-helper.sh was modified as in this PR in a test environment.    Once in place a series of provisions and deprovisions were performed.  No adverse effects were noted, and deprovision was now able to properly control Marvell storage controllers using mvcli.