### PR TITLE
osie-runner: Lets go back to split runtime/buildtime apk calls

### DIFF
--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -6,19 +6,24 @@ VOLUME /statedir
 
 WORKDIR /tmp
 COPY requirements.txt .
+# runtime deps
 RUN apk add --update --upgrade --no-cache \
         bash \
-        curl \
-        alpine-sdk \
         docker \
         jq \
         libstdc++ \
+    && \
+# build time deps
+    apk add --update --upgrade --no-cache --virtual build-deps \
+        alpine-sdk \
+        curl \
         linux-headers \
-        python3-dev
+        python3-dev \
+        ;
 
 RUN pip install -r requirements.txt && \
     python3 -m pip uninstall -y pip && \
-    apk del alpine-sdk linux-headers python3-dev && \
+    apk del build-deps && \
     rm -rf /tmp/* $HOME/.cache
 
 WORKDIR /

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -5,7 +5,6 @@ CMD ["python3", "run.py"]
 VOLUME /statedir
 
 WORKDIR /tmp
-COPY requirements.txt .
 # runtime deps
 RUN apk add --update --upgrade --no-cache \
         bash \
@@ -21,6 +20,7 @@ RUN apk add --update --upgrade --no-cache \
         python3-dev \
         ;
 
+COPY requirements.txt .
 RUN pip install -r requirements.txt && \
     python3 -m pip uninstall -y pip && \
     apk del build-deps && \

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update && apk add --update --upgrade --no-cache \
            libstdc++ \
            linux-headers \
            python3-dev
-# Latest version is ok/on purpose
+
 RUN  pip install -r requirements.txt  \
     &&  python3 -m pip uninstall -y pip \
     && apk del alpine-sdk linux-headers python3-dev \

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -16,10 +16,10 @@ RUN apk update && apk add --update --upgrade --no-cache \
         linux-headers \
         python3-dev
 
-RUN pip install -r requirements.txt \
-    && python3 -m pip uninstall -y pip \
-    && apk del alpine-sdk linux-headers python3-dev \
-    && rm -rf /tmp/* $HOME/.cache
+RUN pip install -r requirements.txt && \
+    python3 -m pip uninstall -y pip && \
+    apk del alpine-sdk linux-headers python3-dev && \
+    rm -rf /tmp/* $HOME/.cache
 
 WORKDIR /
 ADD entrypoint.sh *.py /

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -6,7 +6,7 @@ VOLUME /statedir
 
 WORKDIR /tmp
 COPY requirements.txt .
-RUN apk update && apk add --update --upgrade --no-cache \
+RUN apk add --update --upgrade --no-cache \
         bash \
         curl \
         alpine-sdk \

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -7,21 +7,21 @@ VOLUME /statedir
 WORKDIR /tmp
 COPY requirements.txt .
 RUN apk update && apk add --update --upgrade --no-cache \
-           bash \
-           curl \
-           alpine-sdk \
-           docker \
-           jq \
-           libstdc++ \
-           linux-headers \
-           python3-dev
+        bash \
+        curl \
+        alpine-sdk \
+        docker \
+        jq \
+        libstdc++ \
+        linux-headers \
+        python3-dev
 
-RUN  pip install -r requirements.txt  \
-    &&  python3 -m pip uninstall -y pip \
+RUN pip install -r requirements.txt \
+    && python3 -m pip uninstall -y pip \
     && apk del alpine-sdk linux-headers python3-dev \
     && rm -rf /tmp/* $HOME/.cache
-WORKDIR /
 
+WORKDIR /
 ADD entrypoint.sh *.py /
 
 ARG GITVERSION

--- a/osie-runner/Dockerfile
+++ b/osie-runner/Dockerfile
@@ -15,7 +15,6 @@ RUN apk add --update --upgrade --no-cache \
 # build time deps
     apk add --update --upgrade --no-cache --virtual build-deps \
         alpine-sdk \
-        curl \
         linux-headers \
         python3-dev \
         ;


### PR DESCRIPTION
## Description

Going back to making use of `apk`'s `virtual` package support to separate build-time vs run-time deps. Its just neater this way (DRY).

## How Has This Been Tested?

Ran `docker build`.
