### PR TITLE
Add missing osie- prefix when uploading latest.tar.gz.sha512sum

### DIFF
--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -115,7 +115,7 @@ deploy-to-s3: package
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/osie-$v.tar.gz.sha512sum"
 	mc cp build/osie-$v.tar.gz.sha512sum s3/${s3Bucket}/osie-uploads/osie-$v.tar.gz.sha512sum
 	if [[ $${DRONE_BUILD_EVENT:-} == "push" ]] && [[ $${DRONE_BRANCH:-} == "master" ]]; then
-		sed 's| (.*) | (latest.tar.gz) |' build/$v.tar.gz.sha512sum >build/latest.tar.gz.sha512sum
+		sed 's| (.*) | (latest.tar.gz) |' build/osie-$v.tar.gz.sha512sum >build/latest.tar.gz.sha512sum
 		mc cp s3/tinkerbell-oss/osie-uploads/latest.tar.gz.sha512sum s3/tinkerbell-oss/osie-uploads/latest.tar.gz.sha512sum
 	fi
 	echo "deploy this build from the deploy-osie repo with the following command:"


### PR DESCRIPTION
## Description

Adds `osie-` prefix when looking for the sha512sum file when setting up the copies for `latest` version.

## Why is this needed

Is breaking uploads from master builds.

## How Has This Been Tested?

Tested it manually by setting the appropriate `DRONE_` env vars and changin `mc cp` to `echo mc cp` and verified output.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
