### PR TITLE
make: Modify the "deploy this build..." message

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 osie-test-env: &osie-test-env
-  image: osie-test-env:${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA}
+  image: osie-test-env:${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA:0:8}
 
 clone:
   git:
@@ -12,7 +12,7 @@ pipeline:
   build_osie_test_env_image:
     image: docker
     commands:
-      - docker build -t osie-test-env:${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA} ci
+      - docker build -t osie-test-env:${DRONE_BUILD_NUMBER}-${DRONE_COMMIT_SHA:0:8} ci
       - mkdir build
       - touch build/osie-test-env
     volumes:

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -36,23 +36,6 @@ endif
 
 ifndef v
 v := $(shell git describe --dirty)
-ifeq (-g,$(findstring -g,$v))
-build_git_version := true
-endif
-ifeq (-dirty,$(findstring -dirty,$v))
-build_git_version := true
-endif
-
-ifeq (true,${build_git_version})
-t := $(word 1, $(subst -, ,$v))
-n := $(word 2, $(subst -, ,$v))
-c := $(shell git rev-parse --short HEAD)
-d := ,dirty
-d := $(subst dirty,$d,$(findstring dirty,$v))
-b := $(shell git symbolic-ref HEAD | sed -e 's|^refs/heads/||' -e 's|/|-|g' -e 's|^|,b=|')
-v := $t-n=$n,c=$c$b$d
-v := $(patsubst %dirty,dirty,$v)
-endif
 endif
 
 # ensure build/osie-$v always exists without having to add as an explicit dependency

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -118,11 +118,9 @@ deploy-to-s3: package
 		sed 's| (.*) | (latest.tar.gz) |' build/osie-$v.tar.gz.sha512sum >build/latest.tar.gz.sha512sum
 		mc cp s3/tinkerbell-oss/osie-uploads/latest.tar.gz.sha512sum s3/tinkerbell-oss/osie-uploads/latest.tar.gz.sha512sum
 	fi
-	echo "deploy this build from the deploy-osie repo with the following command:"
-	echo -n "./deploy update osie-$v -m \"$$"
-	echo -n "(sed -n '/^## \[/,$$ {/\S/!q; p}' CHANGELOG.md)\" "
-	echo -n "$$(sed 's|.*= ||' build/osie-$v.tar.gz.sha512sum)"
 	echo
+	echo "EM specific info: deploy this build from the deploy-osie repo with the following command:"
+	echo "./deploy update osie-$v $(shell awk '{print $$NF}' build/osie-$v.tar.gz.sha512sum)"
 
 upload-test: ${packages}
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/osie-testing/osie-$v/"


### PR DESCRIPTION
## Description

Changes the git based version scheme to use just the output of `git describe --dirty` since we don't really need all the other info from before and the format is not allowed as docker image tags.

This PR also truncates the commit sha injected by drone to be just the first 8 hex characters, no need for the full commit id and is much easier to interact with.

Also updating the post deploy-to-s3 message about deploying to production to get rid of EM specific stuff.

## Why is this needed

Local tests fail because the docker osie-test-env image tag that now uses the version info uses forbidden characters (`=` and `,`).

## How Has This Been Tested?

Locally built and CI.

## How are existing users impacted? What migration steps/scripts do we need?

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
