### PR TITLE
Update getbiosconfig to include SMC sum support

### DIFF
--- a/docker/lfs/getbiosconfig
+++ b/docker/lfs/getbiosconfig
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d3d8ae774e6eb1a734aa0d2f55887f1a68826ef71e3e5a209a07d3884cf2afb
-size 3619350
+oid sha256:82456efde51a4db99d5ac9a6783796d1c677de948a1f5464bdd6af1c34455b55
+size 5005147

--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -275,8 +275,9 @@ baremetal_2a2 | baremetal_2a4 | baremetal_hua)
 	if [[ $arch == "x86_64" ]]; then
 		# TODO: post this data to HollowDB when it becomes available
 		# When running the inventorybios command outside of the packet-hardware
-		# container, UTIL_RACADM7 must be set to the location of the racadm binary
-		if UTIL_RACADM7=/opt/dell/srvadmin/bin/idracadm7 packet-hardware inventorybios --verbose -u localhost --dry --cache-file /tmp/bios.json; then
+		# container, UTIL_RACADM7 and UTIL_SUM must be set to the locations of the
+		# racadm and sum binaries, respectively
+		if UTIL_RACADM7=/opt/dell/srvadmin/bin/idracadm7 UTIL_SUM=/opt/supermicro/sum/sum packet-hardware inventorybios --verbose -u localhost --dry --cache-file /tmp/bios.json; then
 			echo "BIOS Inventory reported by packet-hardware:"
 			cat /tmp/bios.json
 		else


### PR DESCRIPTION
This will now work for Dell and Supermicro servers to obtain BIOS
feature status.

Note: I realize that a better solution for updating the getbiosconfig binary would be to start building ironlib as part of the OSIE container. PR#223 is close to completion that will enable multi-stage builds, and I'd like to see that merged before I embark on that effort.