### PR TITLE
EM: Improve the deploy instructions to suggest a message

### DIFF
--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -103,7 +103,7 @@ deploy-to-s3: package
 	fi
 	echo
 	echo "EM specific info: deploy this build from the deploy-osie repo with the following command:"
-	echo "./deploy update osie-$v $(shell awk '{print $$NF}' build/osie-$v.tar.gz.sha512sum)"
+	echo "./deploy update osie-$v $(shell awk '{print $$NF}' build/osie-$v.tar.gz.sha512sum) -m 'Your message to humans here'"
 
 upload-test: ${packages}
 	$(E) "UPLOAD   s3/tinkerbell-oss/osie-uploads/osie-testing/osie-$v/"


### PR DESCRIPTION
## Description

Improve the deploy instructions produced by the CI builds to suggest that the person doing the deploy
add a human friendly message when they do a deploy.

## Why is this needed

This simplifies the deployment documentation

## How Has This Been Tested?

- [x] If this PR CI build spits out the correct instructions, then it worked.