### PR TITLE
Write json output from packet-hardware inventorybios to Hollow

### DIFF
--- a/apps/osie-installer.sh
+++ b/apps/osie-installer.sh
@@ -104,6 +104,8 @@ facility=$(sed -nr 's|.*\bfacility=(\S+).*|\1|p' /proc/cmdline)
 packet_base_url=$(sed -nr 's|.*\bpacket_base_url=(\S+).*|\1|p' /proc/cmdline)
 pwhash=$(sed -nr 's|.*\bpwhash=(\S+).*|\1|p' /proc/cmdline)
 kslug=$(sed -nr 's|.*\bslug=(\S+).*|\1|p' /proc/cmdline)
+hollow_client_id=$(sed -nr 's|.*\bhollow_client_id=(\S+).*|\1|p' /proc/cmdline)
+hollow_client_request_secret=$(sed -nr 's|.*\bhollow_client_request_secret=(\S+).*|\1|p' /proc/cmdline)
 eclypsium_token=$(sed -nr 's|.*\beclypsium_token=(\S+).*|\1|p' /proc/cmdline)
 syslog_host=$(sed -nr 's|.*\bsyslog_host=(\S+).*|\1|p' /proc/cmdline)
 
@@ -229,6 +231,8 @@ $timeout_cmd docker run --privileged -ti \
 	-h "${hardware_id}" \
 	-e "container_uuid=$id" \
 	-e "RLOGHOST=$syslog_host" \
+	-e "HOLLOW_CLIENT_ID=${hollow_client_id:-}" \
+	-e "HOLLOW_CLIENT_REQUEST_SECRET=${hollow_client_request_secret:-}" \
 	-e "ECLYPSIUM_TOKEN=${eclypsium_token:-}" \
 	-v /dev:/dev \
 	-v /dev/console:/dev/console \

--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -273,16 +273,7 @@ baremetal_2a2 | baremetal_2a4 | baremetal_hua)
 	packet-hardware inventory --verbose --tinkerbell "${tinkerbell}/hardware-components"
 	# Catalog various BIOS feature states (not yet supported on aarch64)
 	if [[ $arch == "x86_64" ]]; then
-		# TODO: post this data to HollowDB when it becomes available
-		# When running the inventorybios command outside of the packet-hardware
-		# container, UTIL_RACADM7 and UTIL_SUM must be set to the locations of the
-		# racadm and sum binaries, respectively
-		if UTIL_RACADM7=/opt/dell/srvadmin/bin/idracadm7 UTIL_SUM=/opt/supermicro/sum/sum packet-hardware inventorybios --verbose -u localhost --dry --cache-file /tmp/bios.json; then
-			echo "BIOS Inventory reported by packet-hardware:"
-			cat /tmp/bios.json
-		else
-			echo "WARNING: packet-hardware inventorybios failed on server $id ($class) - needs investigation"
-		fi
+		bios_inventory "${id}" "${class}" "${facility}"
 	fi
 	;;
 esac


### PR DESCRIPTION
Did this in such a way that errors should fail open and log details, rather than failing the deprovision.