### PR TITLE
deprovision: add support for PERC H745

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,8 +98,8 @@ RUN tar -xvC / -f /tmp/osie/megacli-noarch-bin.tar && \
     rm -rf /tmp/osie
 
 # PERC CLI
-COPY lfs/perccli-1.17.10-1.tar.gz /tmp/osie/
-RUN tar -zxvC / -f /tmp/osie/perccli-1.17.10-1.tar.gz && \
+COPY lfs/perccli-7.1020.0000.tar.gz /tmp/osie/
+RUN tar -zxvC / -f /tmp/osie/perccli-7.1020.0000.tar.gz && \
     ln -nsf /opt/MegaRAID/perccli/perccli64 /usr/bin/ && \
     rm -rf /tmp/osie
 

--- a/docker/lfs/perccli-1.17.10-1.tar.gz
+++ b/docker/lfs/perccli-1.17.10-1.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47082be7585a5582a68f1e6dab975ed82bab9df61ee00ac21be705fbafc828e2
-size 4616695

--- a/docker/lfs/perccli-7.1020.0000.tar.gz
+++ b/docker/lfs/perccli-7.1020.0000.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6ef9215137005e4217f5ad06b944da3355a866bb9caad72516c5fa492ba3927
+size 5149091

--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -200,7 +200,7 @@ if [[ $preserve_data == false ]]; then
 	set_autofail_stage "checking/resetting MegaRAID/PERC RAID controllers"
 	# do not do grep -q, it doesn't play well with pipefail when lots of pci devices exist
 	if [[ $arch == "x86_64" ]] && lspci -nn | grep -v 'SAS3008' | grep LSI >/dev/null; then
-		if perccli64 show | grep -E 'PERCH710PMini|PERCH730P|PERCH740PMini' >/dev/null; then
+		if perccli64 show | grep -E 'PERCH710PMini|PERCH730P|PERCH740PMini|PERCH745' >/dev/null; then
 			perc_reset "${disks[@]}"
 		else
 			megaraid_reset "${disks[@]}"

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -800,7 +800,7 @@ function perc_reset() {
 		perccli64 /c0 set personality=HBA
 	fi
 
-	#Check/delete all VDs! -- VDs and VD's it seems
+	#Check/delete all VDs!
 	if perccli64 /c0 /vall show | grep "No VD" >/dev/null; then
 		echo "PERCCLI - No VDs configured - OK"
 	else

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -800,8 +800,8 @@ function perc_reset() {
 		perccli64 /c0 set personality=HBA
 	fi
 
-	#Check/delete all VDs!
-	if perccli64 /c0 /vall show | grep "No VDs" >/dev/null; then
+	#Check/delete all VDs! -- VDs and VD's it seems
+	if perccli64 /c0 /vall show | grep "No VD" >/dev/null; then
 		echo "PERCCLI - No VDs configured - OK"
 	else
 		echo "PERCCLI - Deleting all VDs"

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -788,10 +788,13 @@ function perc_reset() {
 	fi
 
 	#Check/set personality
-	if perccli64 /c0 show personality | grep "Current Personality" | grep "HBA-Mode" >/dev/null; then
-		echo "PERCCLI - Controller in HBA-Mode - OK"
+	if perccli64 /c0 show personality | grep "Current Personality" | grep -E "eHBA|HBA-Mode" >/dev/null; then
+		echo "PERCCLI - Controller in HBA/eHBA-Mode - OK"
 	elif [[ $percmodel == 'PERCH710PMini' || $percmodel == 'PERCH740PMini' ]]; then
 		echo "PERCCLI - Skipping set HBA-Mode. This $percmodel does not support HBA mode"
+	elif [[ $percmodel == 'PERCH745Front' ]]; then
+		echo "PERCCLI - Setting personality to eHBA-Mode"
+		perccli64 /c0 set personality=eHBA
 	else
 		echo "PERCCLI - Setting personality to HBA-Mode"
 		perccli64 /c0 set personality=HBA

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -812,6 +812,8 @@ function perc_reset() {
 	#Check for jbod and enable if needed
 	if perccli64 /c0 show jbod | grep "JBOD      ON" >/dev/null; then
 		echo "PERCCLI - JBOD is on - OK"
+	elif perccli64 /c0 show personality | grep "Auto Configure Behavior JBOD" >/dev/null; then
+		echo "PERCCLI - JBOD auto configure is on - OK"
 	elif [[ $percmodel == 'PERCH710PMini' || $percmodel == 'PERCH740PMini' ]]; then
 		echo "PERCCLI - Skipping set JBOD since $percmodel does not support it"
 	else


### PR DESCRIPTION
Signed-off-by: Dustin Miller <dustin@packet.com>

## Description

Lets do a perc_reset on the Dell PERC H745

## Why is this needed

Seems currently we're not matching this for the perc_reset function
and we get snared trying to run some megacli64 commands.

```
+ MegaCli64 -AdpSetProp -EnableJBOD -1 -a0"
-\r                                     "
Adapter 0: Failed to Set Adapter Properties."
```

## How Has This Been Tested?

Via custom OSIE deprovisions

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 
