### PR TITLE
Avoid sending empty BIOS invetories to Hollow

### DIFF
--- a/apps/osie-installer.sh
+++ b/apps/osie-installer.sh
@@ -230,6 +230,7 @@ reason='docker exited with an error (osie-installer)'
 $timeout_cmd docker run --privileged -ti \
 	-h "${hardware_id}" \
 	-e "container_uuid=$id" \
+	-e "HARDWARE_ID=${hardware_id}" \
 	-e "RLOGHOST=$syslog_host" \
 	-e "HOLLOW_CLIENT_ID=${hollow_client_id:-}" \
 	-e "HOLLOW_CLIENT_REQUEST_SECRET=${hollow_client_request_secret:-}" \

--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -273,7 +273,7 @@ baremetal_2a2 | baremetal_2a4 | baremetal_hua)
 	packet-hardware inventory --verbose --tinkerbell "${tinkerbell}/hardware-components"
 	# Catalog various BIOS feature states (not yet supported on aarch64)
 	if [[ $arch == "x86_64" ]]; then
-		bios_inventory "${id}" "${class}" "${facility}"
+		bios_inventory "${HARDWARE_ID}" "${class}" "${facility}"
 	fi
 	;;
 esac

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -403,9 +403,9 @@ function validate_bios_config() {
 	fi
 }
 
-# usage: bios_inventory $id $plan $facility
+# usage: bios_inventory $hwuuid $plan $facility
 function bios_inventory() {
-	local id=$1
+	local hwuuid=$1
 	local plan=$2
 	local facility=$3
 
@@ -416,10 +416,19 @@ function bios_inventory() {
 	local hollow_json_fn="/tmp/hollow.json"
 	local hollow_namespace="net.equinixplatform.bios"
 	if UTIL_RACADM7=/opt/dell/srvadmin/bin/idracadm7 UTIL_SUM=/opt/supermicro/sum/sum packet-hardware inventorybios --verbose -u localhost --dry --cache-file "${bios_json_fn}"; then
+		local inventorybios_json
+		inventorybios_json="$(cat "${bios_json_fn}")"
+		echo "inventorybios JSON is: [${inventorybios_json}]"
+
+		if [[ ${inventorybios_json} == "{}" ]]; then
+			echo "inventorybios JSON is empty, not writing to Hollow"
+			return 0
+		fi
+
 		# Generate JSON with additional fields required by Hollow
 		if ! jq --null-input \
 			--arg ns "${hollow_namespace}" \
-			--arg id "${id}" \
+			--arg id "${hwuuid}" \
 			--slurpfile data "${bios_json_fn}" \
 			'{Namespace: $ns, hardware_uuid: $id, data: $data[]}' >"${hollow_json_fn}"; then
 			echo "Warning: error while generating hollow json"
@@ -453,7 +462,7 @@ function bios_inventory() {
 			return 0
 		fi
 
-		local hollow_url="https://hollow.edge-a.${facility}.metalkube.net/api/v1/servers/${id}/versioned-attributes"
+		local hollow_url="https://hollow.edge-a.${facility}.metalkube.net/api/v1/servers/${hwuuid}/versioned-attributes"
 		# Write the bios data to Hollow
 		echo "Writing BIOS feature inventory data to ${hollow_url}"
 		local hollow_response
@@ -469,7 +478,7 @@ function bios_inventory() {
 		fi
 		echo "Hollow response: ${hollow_response}"
 	else
-		echo "WARNING: packet-hardware inventorybios failed on server ${id} (${plan}) - needs investigation"
+		echo "WARNING: packet-hardware inventorybios failed on server ${hwuuid} (${plan}) - needs investigation"
 	fi
 
 	set -x

--- a/docker/scripts/functions.sh
+++ b/docker/scripts/functions.sh
@@ -414,7 +414,7 @@ function bios_inventory() {
 	# racadm and sum binaries, respectively
 	local bios_json_fn="/tmp/bios.json"
 	local hollow_json_fn="/tmp/hollow.json"
-	local hollow_namespace="net.equinixplatform.bios"
+	local hollow_namespace="net.platformequinix.bios"
 	if UTIL_RACADM7=/opt/dell/srvadmin/bin/idracadm7 UTIL_SUM=/opt/supermicro/sum/sum packet-hardware inventorybios --verbose -u localhost --dry --cache-file "${bios_json_fn}"; then
 		local inventorybios_json
 		inventorybios_json="$(cat "${bios_json_fn}")"


### PR DESCRIPTION
The 'packet-hardware inventorybios' command can succeed but generate
empty BIOS JSON on unsupported platforms. Check for this and avoid
writing to Hollow in these cases.

The `$id` that we get from metadata is the instance uuid, not the hardware uuid. Make the hwuuid available to osie scripts by passing it down via osie runner's docker env.

Also fixed a typo in the hollow namespace.