### PR TITLE
osie: update racadm to v10.1.0.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,12 +134,10 @@ RUN cd /tmp/osie && \
     if [ "$(uname -m)" != 'aarch64' ]; then \
       apt-get update && apt-get install -y alien && \
       rpm --import http://linux.dell.com/repo/pgp_pubkeys/0x1285491434D8786F.asc && \
-      wget \
-        https://dl.dell.com/FOLDER05920767M/1/DellEMC-iDRACTools-Web-LX-9.4.0-3732_A00.tar.gz \
-        http://linux.dell.com/repo/community/openmanage/940/bionic/pool/main/s/srvadmin-omilcore/srvadmin-omilcore_9.4.0_amd64.deb && \
-      tar -xvf DellEMC-iDRACTools-Web-LX-9.4.0-3732_A00.tar.gz && \
-      alien -i iDRACTools/racadm/RHEL8/x86_64/*.rpm && \
-      dpkg -i *.deb && \
+      wget --quiet https://dl.dell.com/FOLDER07423496M/1/DellEMC-iDRACTools-Web-LX-10.1.0.0-4566_A00.tar.gz && \
+      tar --extract --file DellEMC-iDRACTools-Web-LX-10.1.0.0-4566_A00.tar.gz && \
+      alien --install iDRACTools/racadm/RHEL8/x86_64/*.rpm && \
+      ln -s /opt/dell/srvadmin/bin/idracadm7 /usr/bin/racadm && \
       apt-get purge -y alien && \
       apt-get autoremove -y && \
       cp dchipm.ini /opt/dell/srvadmin/etc/srvadmin-hapi/ini/ ; \


### PR DESCRIPTION
Lets upgrade racadm to v10 and symlink it to a good spot for easier access

This also slims the build a bit and quiets some of the noise

Inspired by https://github.com/tinkerbell/osie/pull/232

Signed-off-by: Dustin Miller <dustin@packet.com>

## Description

Upgrade Dell's racadm utility to v10.1

## Why is this needed

Latest and greatest?

Fixes: #

## How Has This Been Tested?
I tested many provisions and deprovisions

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 

