### PR TITLE
grub: add deb11 and ubu21 defaults

### DIFF
--- a/grub/debian_11-default-grub.template
+++ b/grub/debian_11-default-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Debian' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Debian - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/debian_11-default-grub.template.default
+++ b/grub/debian_11-default-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_04-default-grub.template
+++ b/grub/ubuntu_21_04-default-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_04-default-grub.template.default
+++ b/grub/ubuntu_21_04-default-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'

--- a/grub/ubuntu_21_10-default-grub.template
+++ b/grub/ubuntu_21_10-default-grub.template
@@ -1,0 +1,71 @@
+# Set menu colors
+set menu_color_normal=white/green
+set menu_color_highlight=light-red/white
+
+# Set menu display time
+set timeout=3
+
+# Set the default boot entry (first is 0)
+set default=0
+
+# Set the root variable - grub2 uses this to find files if the
+# root device is not specified in the entry itself.
+# It can be set explicitly like so:
+
+#set root='(hd0,1)'
+
+# Define console settings
+#serial console=tty0 console=ttyS1,115200n8
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+terminal --timeout=10 serial console
+
+# Or it can be set using grub2's builtin search feature like so:
+
+#search --no-floppy --fs-uuid --set root xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb
+search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+
+# The string xxxxxxxx-yyyy-zzzz-aaaa-bbbbbbbbbbbb should be replaced with
+# the proper UUID for the root device. It can be found using 'blkid' from
+# util-linux.
+
+# Boot entries:
+
+# Linux
+menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 $vt_handoff
+		initrd /boot/initrd
+}
+
+# Linux single
+menuentry 'Ubuntu - single user mode' --class ubuntu --class gnu-linux --class gnu {
+		insmod gzio
+		insmod part_msdos
+		insmod part_msdos
+		insmod diskfilter
+		insmod mdraid1x
+		insmod ext2
+		insmod gptsync
+		insmod part_gpt
+		set root='(mduuid/PACKET_ROOT_UUID)'
+		if [ x$feature_platform_search_hint = xy ]; then
+		  search --no-floppy --fs-uuid --set=root --hint='mduuid/PACKET_ROOT_UUID'  PACKET_ROOT_UUID
+		else
+		  search --no-floppy --fs-uuid --set=root PACKET_ROOT_UUID
+		fi
+		linux  /boot/vmlinuz root=UUID=PACKET_ROOT_UUID ro serial console=tty0 console=ttyS1,115200n8 single
+		initrd /boot/initrd
+}

--- a/grub/ubuntu_21_10-default-grub.template.default
+++ b/grub/ubuntu_21_10-default-grub.template.default
@@ -1,0 +1,2 @@
+GRUB_CMDLINE_LINUX='console=tty0 console=ttyS1,115200n8'
+GRUB_SERIAL_COMMAND='serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1'


### PR DESCRIPTION
## Description

Add default GRUB templates for Debian 11 and Ubuntu 21

## Why is this needed

Provisions will fail without these

## How Has This Been Tested?

Just in theory

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 
