### PR TITLE
detect vmx/svm and fall back to qemu software mode

### DIFF
--- a/ci/vm.sh
+++ b/ci/vm.sh
@@ -268,7 +268,7 @@ run_vm() {
 
 	# fall back to qemu software mode when KVM isn't available
 	local kvm_accel=",accel=kvm:tcg"
-	if ! (grep -Eq ' (svm|vmx)' /proc/cpuinfo) ; then
+	if ! (grep -Eq ' (svm|vmx)' /proc/cpuinfo); then
 		cpu=qemu64
 		kvm_accel=""
 	fi
@@ -305,7 +305,7 @@ run_vm() {
 		-monitor unix:monitor.sock,server=on,wait=off \
 		-nographic \
 		"${serials[@]}" \
-		-machine $machine$kvm_accel -cpu $cpu -smp 2 -m 8192 \
+		-machine "$machine$kvm_accel" -cpu $cpu -smp 2 -m 8192 \
 		-drive if=virtio,file="$disk",format=raw,discard=unmap \
 		-object rng-random,filename=/dev/urandom,id=rng0 \
 		-device virtio-rng-pci,rng=rng0 \


### PR DESCRIPTION
## Description

Looks for the vmx/svm cpu flags in /proc/cpuinfo and falls back to qemu software mode when they're not present.

## Why is this needed

Makes it possible to run the VM test on a VM.

I do most of my work in an Xhyve/hyperkit VM on my Mac. This change makes it so the VM will start up in my dev environment and probably makes it more readily available to others.

## How are existing users impacted? What migration steps/scripts do we need?

Should be no change for most folks.

I have not tested on bare metal yet as I don't have a machine set up right now.

