### PR TITLE
Remove unnecessary plan check during mdadm config update.

### DIFF
--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -285,10 +285,8 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 	phone_home "${tinkerbell}" '{"type":"provisioning.106"}'
 
 	mkdir -p $target/etc/mdadm
-	if [[ $class != "t1.small.x86" ]]; then
-		echo -e "${GREEN}#### Updating MD RAID config file ${NC}"
-		mdadm --examine --scan >>$target/etc/mdadm/mdadm.conf
-	fi
+	echo -e "${GREEN}#### Updating MD RAID config file ${NC}"
+	mdadm --examine --scan >>$target/etc/mdadm/mdadm.conf
 
 	# ensure unique dbus/systemd machine-id
 	set_autofail_stage "machine-id setup"


### PR DESCRIPTION
Plan check was not required because we see the same behavior for all plans.

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
