### PR TITLE
deprovision: add bios_inventory autofail stage

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -268,7 +268,9 @@ baremetal_2a2 | baremetal_2a4 | baremetal_hua)
 *)
 	set_autofail_stage "running packet-hardware inventory"
 	packet-hardware inventory --verbose --tinkerbell "${tinkerbell}/hardware-components"
+
 	# Catalog various BIOS feature states (not yet supported on aarch64)
+	set_autofail_stage "running bios_inventory"
 	if [[ $arch == "x86_64" ]]; then
 		bios_inventory "${HARDWARE_ID}" "${class}" "${facility}"
 	fi


### PR DESCRIPTION
We were doing two separate things in a single autofail stage which makes
it harder to debug what might be failing.

Signed-off-by: Dustin Miller <dustin@packet.com>

## Description

Adds another autofail stage for clarity

## Why is this needed

Quicker debugging

## How Has This Been Tested?

Theory only

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 