### PR TITLE
Include the asrockrack bios kernel module

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 docker/lfs/* filter=lfs diff=lfs merge=lfs -text
 installer/alpine/assets-*/* filter=lfs diff=lfs merge=lfs -text
 installer/alpine/eclypsiumdriver-alpine-2.0.0.tgz filter=lfs diff=lfs merge=lfs -text
+installer/alpine/BIOSControl_v1.0.3.zip filter=lfs diff=lfs merge=lfs -text

--- a/installer/alpine/BIOSControl_v1.0.3.zip
+++ b/installer/alpine/BIOSControl_v1.0.3.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df4c7338a07d2b7b55460355e1ad675333e1992eeafa1d293df35b55fab2524e
+size 1380725

--- a/installer/alpine/Dockerfile
+++ b/installer/alpine/Dockerfile
@@ -28,6 +28,7 @@ RUN true && \
         coreutils \
         linux-headers \
         sudo \
+        unzip \
         && \
     adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder && \
     echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
@@ -95,6 +96,23 @@ RUN echo "${ECLYPSIUM_DRIVER_SHA512}  ${ECLYPSIUM_DRIVER_FILENAME}" | sha512sum 
     abuild clean && \
     sudo apk add --no-scripts --no-cache --update --upgrade --cache-dir /tmp/non-persisted-apk-cache-dir \
         /home/builder/packages/non-free/x86_64/eclypsium*.apk
+
+# Build and install the ASRR BIOS utility and kernel module
+ARG ASRR_BIOS_DRIVER_VERSION=1.0
+ARG ASRR_BIOS_DRIVER_SHA512=5dbb458dd105d872f61f0256ec1a57c5de922328a23cd42e636b35c5bbda7e1e1d957b271de76b49345c35a55a97845842de106aea61f930ac440ad6e21f344a
+ARG ASRR_BIOS_DRIVER_FILENAME="BIOSControl_v1.0.3.zip"
+
+COPY ${ASRR_BIOS_DRIVER_FILENAME} /home/builder/
+RUN echo "${ASRR_BIOS_DRIVER_SHA512} ${ASRR_BIOS_DRIVER_FILENAME}" | sha512sum -c && \
+    unzip ${ASRR_BIOS_DRIVER_FILENAME} && \
+    # def for 5.x kernel build
+    echo '#define LINUX_VERSION_500 0' > driver/ver.h && \
+    # build module
+    make -C /lib/modules/${KERNEL}-${PKGREL}-${FLAVOR}/build M=/home/builder/driver && \
+    # install module
+    sudo install -D -m 600 driver/asrdev.ko /lib/modules/${KERNEL}-${PKGREL}-${FLAVOR}/extra/ && \
+    # clean up
+    rm -rf /home/builder/BIOSControl /home/builder/driver /home/builder/ReadMe.txt
 
 # Remove built and installed packages, these never get installed at runtime
 RUN rm -rf /home/builder/packages/*

--- a/installer/alpine/build.sh
+++ b/installer/alpine/build.sh
@@ -6,6 +6,11 @@ set -o errexit -o nounset -o pipefail -o xtrace
 [[ $(uname -m) == aarch64 ]] && echo "aarch64 isn't _really_ tested/supported yet" && exit 1
 
 build_initramfs() {
+	# Asrockrack kernel module
+	cat >/etc/mkinitfs/features.d/asrockrack.modules <<-EOF
+		extra/asrdev.ko
+	EOF
+
 	# Eclypsium driver and supporting modules (IPMI)
 	cat >/etc/mkinitfs/features.d/eclypsium.modules <<-EOF
 		extra/eclypsiumdriver.ko


### PR DESCRIPTION
## Description

This change updates the alpine image to build and include the `asrdev.ko` kernel module,
which enables the Asrockrack BIOS utility `BIOSControl` to set/get BIOS configuration.

## Why is this needed

To export and import BIOS configuration on the Asrockrack hardware.

## How Has This Been Tested?

By building the Alpine docker image