### PR TITLE
Log error when disk is not detected

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -71,6 +71,12 @@ function autofail() {
 }
 trap autofail EXIT
 
+set_autofail_stage "checking for disk drives"
+if [[ ${#disks[@]} -eq 0 ]]; then
+	echo "Error: No disk drives detected"
+	exit 1
+fi
+
 # Check BIOS config and update if drift is detected
 if [[ $arch == "x86_64" ]] && [[ $reserved != "true" ]]; then
 	set_autofail_stage "detecting BIOS information"


### PR DESCRIPTION
Issue: deprovisioning fails with this message "disks[@]: unbound variable" if no
disks are detected.

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
