### PR TITLE
improve: remove match detection from centos.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN cd /tmp/osie && \
     rm -rf /tmp/osie/
 
 ARG PACKET_HARDWARE_COMMIT=ddbafcbc74ef3db0677d56733442cd9f6f76a317
-ARG PACKET_NETWORKING_COMMIT=06061801efaf34caa8d8b1ae5973c15e5a23659d
+ARG PACKET_NETWORKING_COMMIT=2ac8cbd684195ade26b514a9870c71fd3902ad6e
 
 RUN curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 && \
     pip3 install git+https://github.com/packethost/packet-hardware.git@${PACKET_HARDWARE_COMMIT} && \

--- a/docker/scripts/centos.sh
+++ b/docker/scripts/centos.sh
@@ -50,14 +50,6 @@ DVER=$2
 echo "#### Detected OS on mounted target $TARGET"
 echo "OS: $DOS  ARCH: $arch VER: $DVER"
 
-# Match detected OS to known OS config
-if [[ $DOS == "CentOS" ]] || [[ $DOS == "RedHatEnterpriseServer" ]] || [[ $DOS == "RedHatEnterprise" ]] || [[ $DOS == "openSUSEproject" ]]; then
-	echo "Configuring Redhat based distro extras"
-else
-	echo "Error: Detected OS $DOS not matched"
-	exit 1
-fi
-
 if [[ -f "$TARGET/etc/sysconfig/selinux" ]] && [[ $DOS != "RedHatEnterpriseServer" ]]; then
 	echo "Disabling SELinux"
 	sed -i --follow-symlinks 's/SELINUX=enforcing/SELINUX=disabled/g' "$TARGET/etc/sysconfig/selinux"


### PR DESCRIPTION
## Description

Removes match detection from centos.sh

This detection only hinders progress. It means that every new possible 
RedHat based OS will require an addition here. Instead, we can simply 
remove this since at best case it echos, every other case it halts 
progress.

Also updates packet-networking to the latest (more flavor support)

## Why is this needed

Allows for expanded RedHat based OS support

## How Has This Been Tested?

Via custom OSIE deployments

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 