### PR TITLE
osie/alpine: blacklist ipmi modules

### DIFF
--- a/docker/scripts/deprovision.sh
+++ b/docker/scripts/deprovision.sh
@@ -262,6 +262,11 @@ fi
 
 # Run packet-hardware inventory to update API components and firmware details
 set_autofail_stage "running packet-hardware inventory"
+
+if ! modprobe ipmi_si ipmi_devintf; then
+	echo "Unable to modprobe si_ipmi or ipmi_devintf"
+fi
+
 if ! packet-hardware inventory --verbose --tinkerbell "${tinkerbell}/hardware-components"; then
 	echo "Warning: packet-hardware inventory failed for server ${id} (${class})"
 fi

--- a/rules.mk.j2
+++ b/rules.mk.j2
@@ -145,6 +145,8 @@ build/osie-$v/%.tar.gz: build/%.tar.gz
 build/osie-$v/initramfs-{{platform}}: build/osie-$v-rootfs-{{platform}} installer/alpine/init-{{arch}}
 	$(E) "CPIO     $@"
 	install -m755 installer/alpine/init-{{arch}} build/osie-$v-rootfs-{{platform}}/init
+	echo 'blacklist ipmi_si' >> build/osie-$v-rootfs-{{platform}}/etc/modprobe.d/boot-opt-blacklist.conf
+	echo 'blacklist ipmi_devintf' >> build/osie-$v-rootfs-{{platform}}/etc/modprobe.d/boot-opt-blacklist.conf
 	(cd build/osie-$v-rootfs-{{platform}} && find -print0 | bsdcpio --null --quiet -oH newc | pigz -9) >$@.osied
 	install -D -m644 $@.osied $@
 	touch $@


### PR DESCRIPTION
## Description

Lets blacklist these two IPMI related modules for faster boot times

## How Has This Been Tested?

Drone, manually

## How are existing users impacted? What migration steps/scripts do we need?

No break, only fix :crossed_fingers: 
