### PR TITLE
Update curl requests to retry 7x (~127 seconds)

### DIFF
--- a/apps/rescue-helper.sh
+++ b/apps/rescue-helper.sh
@@ -23,10 +23,10 @@ See docs at http://wiki.alpinelinux.org
 EOF
 
 mkdir -p /root/.ssh
-curl -sSLf https://metadata.packet.net/2009-04-04/meta-data/public-keys >/root/.ssh/authorized_keys
+curl -sSLf --retry 7 https://metadata.packet.net/2009-04-04/meta-data/public-keys >/root/.ssh/authorized_keys
 
 tinkerbell=$(sed -nr 's|.*\btinkerbell=(\S+).*|\1|p' /proc/cmdline)
 
-curl -X POST -vs "$tinkerbell/phone-home" 2>&1 | logger -t phone_home
+curl --retry 7 -X POST -vs "$tinkerbell/phone-home" 2>&1 | logger -t phone_home
 
 mdadm --assemble --scan || :

--- a/docker/build-lshw.sh
+++ b/docker/build-lshw.sh
@@ -6,7 +6,7 @@ LSHW_RELEASE=B.02.18
 LSHW_SHA512=090b79c144e4a42dd88a0a6d6992183d747ea891850f67403e0b63037b84d4b1891f2ad38f9151393b5ec1ac987b7ae70083c0f6eb8611f89d372a461390e8f3
 LSHW_BASEURL=https://github.com/lyonel/lshw/archive
 
-curl -L "${LSHW_BASEURL}/${LSHW_RELEASE}.tar.gz" >lshw.tar.gz
+curl --retry 7 -L "${LSHW_BASEURL}/${LSHW_RELEASE}.tar.gz" >lshw.tar.gz
 echo "${LSHW_SHA512}  lshw.tar.gz" | sha512sum -c
 tar -zxvf lshw.tar.gz
 cd lshw-${LSHW_RELEASE}/src

--- a/docker/build-mstflint.sh
+++ b/docker/build-mstflint.sh
@@ -6,7 +6,7 @@ MSTFLINT_RELEASE=4.14.0-1
 MSTFLINT_SHA512=965b25141d1b960bb575fc9fb089e912b0408af72919d23f295c6a8e8650c95c9459cb496171dca7f818252a180bd85bee8ed0f876159279013828478a0c2101
 MSTFLINT_BASEURL=https://github.com/Mellanox/mstflint/releases/download/
 
-curl -L "${MSTFLINT_BASEURL}/v${MSTFLINT_RELEASE}/mstflint-${MSTFLINT_RELEASE}.tar.gz" >mstflint.tar.gz
+curl --retry 7 -L "${MSTFLINT_BASEURL}/v${MSTFLINT_RELEASE}/mstflint-${MSTFLINT_RELEASE}.tar.gz" >mstflint.tar.gz
 apt install -y zlib1g-dev libibmad-dev libssl-dev g++
 echo "${MSTFLINT_SHA512}  mstflint.tar.gz" | sha512sum -c
 tar -zxvf mstflint.tar.gz

--- a/docker/build-nvme-cli.sh
+++ b/docker/build-nvme-cli.sh
@@ -6,7 +6,7 @@ NVMECLI_RELEASE=1.8.1
 NVMECLI_SHA512=b31690f6dbc1f88ebd461636b452b8dedc6e1f67e2fe9d088b1f1d2ddf634ab6ef8d628d2c7fdc6977587d9565deb816a1df8f4881759a12b030a190af5c9095
 NVMECLI_BASEURL=https://github.com/linux-nvme/nvme-cli/archive
 
-curl -L "${NVMECLI_BASEURL}/v${NVMECLI_RELEASE}.tar.gz" >nvme-cli.tar.gz
+curl --retry 7 -L "${NVMECLI_BASEURL}/v${NVMECLI_RELEASE}.tar.gz" >nvme-cli.tar.gz
 echo "${NVMECLI_SHA512}  nvme-cli.tar.gz" | sha512sum -c
 tar -zxvf nvme-cli.tar.gz
 cd nvme-cli-${NVMECLI_RELEASE}

--- a/docker/build-smartmontools.sh
+++ b/docker/build-smartmontools.sh
@@ -7,7 +7,7 @@ SMARTMONTOOLS_TARNAME=smartmontools-7.1
 SMARTMONTOOLS_SHA512=440b2a957da10d240a8ef0008bd3358b83adb9eaca0f8d3e049b25d56a139c61dcd0bb4b27898faef6f189a27e159bdca3331e52e445c0eebf35e5d930f9e295
 SMARTMONTOOLS_BASEURL=https://github.com/smartmontools/smartmontools/releases/download/
 
-curl -L "${SMARTMONTOOLS_BASEURL}/${SMARTMONTOOLS_RELEASE}/${SMARTMONTOOLS_TARNAME}.tar.gz" >smartmontools.tar.gz
+curl -L --retry 7 "${SMARTMONTOOLS_BASEURL}/${SMARTMONTOOLS_RELEASE}/${SMARTMONTOOLS_TARNAME}.tar.gz" >smartmontools.tar.gz
 echo "${SMARTMONTOOLS_SHA512}  smartmontools.tar.gz" | sha512sum -c
 tar -zxvf smartmontools.tar.gz
 cd "$SMARTMONTOOLS_TARNAME"

--- a/docker/scripts/osie.sh
+++ b/docker/scripts/osie.sh
@@ -147,7 +147,7 @@ if [[ -z ${cpr_url} ]]; then
 else
 	echo "NOTICE: Custom CPR url found!"
 	echo "Overriding default CPR location with custom cpr_url"
-	if ! curl "$cpr_url" | jq . >$cprconfig; then
+	if ! rcurl "$cpr_url" | jq . >$cprconfig; then
 		phone_home "${tinkerbell}" '{"instance_id":"'"$(jq -r .id "$metadata")"'"}'
 		echo "$0: CPR URL unavailable: $cpr_url" >&2
 		exit 1
@@ -202,10 +202,10 @@ if ! [[ -f /statedir/disks-partioned-image-extracted ]]; then
 		git -C $assetdir checkout FETCH_HEAD
 	elif [[ $image_uri =~ ^https:// ]]; then
 		echo -e "${GREEN}#### Adding custom uri: ${image_uri}${NC}"
-		curl --retry 3 "${image_uri}/image.tar.gz" --output "$assetdir/image.tar.gz"
-		curl --retry 3 "${image_uri}/initrd.tar.gz" --output "$assetdir/initrd.tar.gz"
-		curl --retry 3 "${image_uri}/kernel.tar.gz" --output "$assetdir/kernel.tar.gz"
-		curl --retry 3 "${image_uri}/modules.tar.gz" --output "$assetdir/modules.tar.gz"
+		rcurl "${image_uri}/image.tar.gz" --output "$assetdir/image.tar.gz"
+		rcurl "${image_uri}/initrd.tar.gz" --output "$assetdir/initrd.tar.gz"
+		rcurl "${image_uri}/kernel.tar.gz" --output "$assetdir/kernel.tar.gz"
+		rcurl "${image_uri}/modules.tar.gz" --output "$assetdir/modules.tar.gz"
 	else
 		echo -e "${RED}#### Image URI is not https: ${image_uri}${NC}"
 		exit 1
@@ -529,7 +529,7 @@ logger -s -t phone_home "Making a call to tell the packet API is online."
 # doesn't hurt to log as much as we can in case it fails.
 n=1
 until [ \$n -ge 6 ] || [ "\${PIPESTATUS[0]}" -eq 0 ]; do
-	curl -X PUT -H "Content-Type: application/json" -vs -d '{"instance_id": "$(jq -r .id "$metadata")"}' "$tinkerbell/phone-home" 2>&1 | logger -s -t phone_home
+	curl --retry 7 -X PUT -H "Content-Type: application/json" -vs -d '{"instance_id": "$(jq -r .id "$metadata")"}' "$tinkerbell/phone-home" 2>&1 | logger -s -t phone_home
 
 	if [ "\${PIPESTATUS[0]}" -eq 0 ]; then
 		logger -s -t phone_home "This device has been announced to the packet API."

--- a/docker/scripts/vosie.sh
+++ b/docker/scripts/vosie.sh
@@ -105,7 +105,7 @@ if [[ -z ${cpr_url} ]]; then
 else
 	echo "NOTICE: Custom CPR url found!"
 	echo "Overriding default CPR location with custom cpr_url"
-	if ! curl "$cpr_url" | jq . >$cprconfig; then
+	if ! rcurl "$cpr_url" | jq . >$cprconfig; then
 		phone_home "${tinkerbell}" '{"instance_id":"'"$(jq -r .id "$metadata")"'"}'
 		echo "$0: CPR URL unavailable: $cpr_url" >&2
 		exit 1
@@ -492,6 +492,7 @@ function puttink() {
 	local post_data=$3
 
 	curl \
+		--retry 7 \
 		-f \
 		-vvvvv \
 		-X PUT \

--- a/docker/scripts/wosie.sh
+++ b/docker/scripts/wosie.sh
@@ -148,7 +148,7 @@ set_autofail_stage "writing rootfs to disk"
 tmpfile=/tmp/image.tar.gz
 if should_stream "$image" ${tmpfile%/*}; then
 	echo -e "${GREEN}#### Retrieving and extracting image archive to first disk in one shot${NC}"
-	curl -sL "$image" | pv -bnti 5 | tar -zxOf- | dd bs=512k of="$install_disk"
+	rcurl -sL "$image" | pv -bnti 5 | tar -zxOf- | dd bs=512k of="$install_disk"
 else
 	echo -e "${GREEN}#### Retrieving image archive${NC}"
 	wget --quiet "$image" -O $tmpfile

--- a/docker/tests/test_functions.sh
+++ b/docker/tests/test_functions.sh
@@ -102,7 +102,7 @@ test_ensure_reachable() {
 test_filter_bad_devs() {
 	local devs
 	devs=$(
-		curl -sf https://raw.githubusercontent.com/torvalds/linux/master/Documentation/admin-guide/devices.txt |
+		curl --retry 7 -sf https://raw.githubusercontent.com/torvalds/linux/master/Documentation/admin-guide/devices.txt |
 			grep -E 'block\s*(Loopback devices|SCSI disk)' |
 			awk '{print $1}'
 		echo -e '251\n253\n259' # virtio disks seen in tests


### PR DESCRIPTION
Signed-off-by: Thomas Stromberg <t+github@stromberg.org>

## Description

Update curl calls to retry 7x, or just long enough to survive a 2-minute outage (not including other connection overhead).

This defines and uses an `rcurl` alias where convenient, but in some locations, such as where scripts are written to disk, it uses `--retry 7`. Both behave equivalently.

## Why is this needed

In production, we've occasionally seen instances where metadata servers are busy and/or otherwise unavailable. This will allow provisioning jobs to survive these momentary availability blips and transient networking issues.

## How Has This Been Tested?

It hasn't.
